### PR TITLE
Add rules against DOM methods as variable value

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -181,13 +181,31 @@ https://github.com/reactjs/reactjs.org/issues/4626#issuecomment-1117535930`,
       },
       {
         selector:
+          "VariableDeclaration VariableDeclarator CallExpression[callee.object.name='document'][callee.property.name='querySelector']",
+        message: `Using document.querySelector() can lead to problems, and is not commonly used in React code - prefer instead usage of basic React patterns such as state and controlled components
+https://github.com/reactjs/reactjs.org/issues/4626#issuecomment-1117535930`,
+      },
+      {
+        selector:
           "ExpressionStatement CallExpression[callee.object.name='document'][callee.property.name='querySelectorAll']",
         message: `Using document.querySelectorAll() can lead to problems, and is not commonly used in React code - prefer instead usage of basic React patterns such as state and controlled components
 https://github.com/reactjs/reactjs.org/issues/4626#issuecomment-1117535930`,
       },
       {
         selector:
+          "VariableDeclaration VariableDeclarator CallExpression[callee.object.name='document'][callee.property.name='querySelectorAll']",
+        message: `Using document.querySelectorAll() can lead to problems, and is not commonly used in React code - prefer instead usage of basic React patterns such as state and controlled components
+https://github.com/reactjs/reactjs.org/issues/4626#issuecomment-1117535930`,
+      },
+      {
+        selector:
           "ExpressionStatement CallExpression[callee.object.name='document'][callee.property.name='getElementById']",
+        message: `Using document.getElementById() can lead to problems, and is not commonly used in React code - prefer instead usage of basic React patterns such as state and controlled components
+https://github.com/reactjs/reactjs.org/issues/4626#issuecomment-1117535930`,
+      },
+      {
+        selector:
+          "VariableDeclaration VariableDeclarator CallExpression[callee.object.name='document'][callee.property.name='getElementById']",
         message: `Using document.getElementById() can lead to problems, and is not commonly used in React code - prefer instead usage of basic React patterns such as state and controlled components
 https://github.com/reactjs/reactjs.org/issues/4626#issuecomment-1117535930`,
       },


### PR DESCRIPTION
With the current config, we are baning only the usage of document methods directly in the code (which is good but not complete)

for example:

```
function (){
document.querySelector('div')
}

```

This PR add also a bans the more common usage of this method being assigned to a variable

```
function (){
const divRef = document.querySelector('div')
}

```
