### PR TITLE
Add configuration for Next.js 13 app/ dir (#183)ude 

### DIFF
--- a/templates/tsconfig.json
+++ b/templates/tsconfig.json
@@ -1,4 +1,15 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "@upleveled/eslint-config-upleveled/tsconfig.base.json"
+  "extends": "@upleveled/eslint-config-upleveled/tsconfig.base.json",
+  "include": [
+    "**/.eslintrc.cjs",
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.cjs",
+    "**/*.mjs",
+    ".next/types/**/*.ts"
+  ]
 }

--- a/templates/tsconfig.json
+++ b/templates/tsconfig.json
@@ -3,13 +3,13 @@
   "extends": "@upleveled/eslint-config-upleveled/tsconfig.base.json",
   "include": [
     "**/.eslintrc.cjs",
-    "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
     "**/*.js",
     "**/*.jsx",
     "**/*.cjs",
     "**/*.mjs",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    "next-env.d.ts"
   ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,15 +21,5 @@
     "incremental": true,
     "noUncheckedIndexedAccess": true
   },
-  "include": [
-    "../../../**/.eslintrc.cjs",
-    "../../../next-env.d.ts",
-    "../../../**/*.ts",
-    "../../../**/*.tsx",
-    "../../../**/*.js",
-    "../../../**/*.jsx",
-    "../../../**/*.cjs",
-    "../../../**/*.mjs"
-  ],
   "exclude": ["../../../node_modules", "../../../build"]
 }


### PR DESCRIPTION
Since we are teaching `app/` dir architecture from winter 2023, some changes are needed to the ESLint config for Next.js

Moving the `include` array into the template was necessary because Next.js tries to modify `tsconfig.json`, causing this error:

```
TypeError: Cannot read properties of undefined (reading 'push')
    at Object.writeConfigurationDefaults (/Users/josehower/projects/next-13-demo-project/node_modules/next/dist/lib/typescript/writeConfigurationDefaults.js:207:30)
    at async Object.verifyTypeScriptSetup (/Users/josehower/projects/next-13-demo-project/node_modules/next/dist/lib/verifyTypeScriptSetup.js:116:9)
    at async DevServer.verifyTypeScript (/Users/josehower/projects/next-13-demo-project/node_modules/next/dist/server/dev/next-dev-server.js:486:34)
    at async DevServer.prepare (/Users/josehower/projects/next-13-demo-project/node_modules/next/dist/server/dev/next-dev-server.js:508:9)
    at async /Users/josehower/projects/next-13-demo-project/node_modules/next/dist/cli/next-dev.js:336:17
error Command failed with exit code 1.
```