### PR TITLE
Enable Stylelint linting for CSS Modules + scss

### DIFF
--- a/__tests__/stylelint.config.cjs
+++ b/__tests__/stylelint.config.cjs
@@ -3,6 +3,8 @@ const config = {
   extends: [
     'stylelint-config-recommended',
     'stylelint-config-styled-components',
+    'stylelint-config-recommended-scss',
+    'stylelint-config-css-modules',
     'stylelint-config-prettier',
   ],
   rules: {

--- a/__tests__/stylelint.config.cjs
+++ b/__tests__/stylelint.config.cjs
@@ -9,6 +9,8 @@ const config = {
   ],
   rules: {
     'no-descending-specificity': null,
+    // Allow files without any styles in them
+    'no-empty-source': null,
   },
   overrides: [
     {

--- a/package.json
+++ b/package.json
@@ -48,8 +48,10 @@
     "postcss": "8.4.20",
     "postcss-scss": "4.0.6",
     "stylelint": "14.16.1",
+    "stylelint-config-css-modules": "4.1.0",
     "stylelint-config-prettier": "9.0.4",
     "stylelint-config-recommended": "9.0.0",
+    "stylelint-config-recommended-scss": "8.0.0",
     "stylelint-config-styled-components": "0.1.1",
     "stylelint-processor-styled-components": "1.10.0",
     "typescript": "4.9.4"
@@ -83,8 +85,10 @@
     "postcss": "8.4.20",
     "postcss-scss": "4.0.6",
     "stylelint": "14.16.1",
+    "stylelint-config-css-modules": "4.1.0",
     "stylelint-config-prettier": "9.0.4",
     "stylelint-config-recommended": "9.0.0",
+    "stylelint-config-recommended-scss": "8.0.0",
     "stylelint-config-styled-components": "0.1.1",
     "stylelint-processor-styled-components": "1.10.0",
     "typescript": "4.9.4"

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -3,6 +3,8 @@ const config = {
   extends: [
     'stylelint-config-recommended',
     'stylelint-config-styled-components',
+    'stylelint-config-recommended-scss',
+    'stylelint-config-css-modules',
     'stylelint-config-prettier',
   ],
   rules: {

--- a/templates/stylelint.config.cjs
+++ b/templates/stylelint.config.cjs
@@ -3,6 +3,8 @@ const config = {
   extends: [
     'stylelint-config-recommended',
     'stylelint-config-styled-components',
+    'stylelint-config-recommended-scss',
+    'stylelint-config-css-modules',
     'stylelint-config-prettier',
   ],
   rules: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2789,7 +2789,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.2:
+json5@^2.2.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -3215,12 +3215,12 @@ postcss-safe-parser@^6.0.0:
   resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz#bb4c29894171a94bc5c996b9a30317ef402adaa1"
   integrity sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==
 
-postcss-scss@4.0.6:
+postcss-scss@4.0.6, postcss-scss@^4.0.2:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-4.0.6.tgz#5d62a574b950a6ae12f2aa89b60d63d9e4432bfd"
   integrity sha512-rLDPhJY4z/i4nVFZ27j9GqLxj1pwxE80eAzUNRMXtcpipFYIeowerzBgG3yJhMtObGEXidtIgbUpQ3eLDsf5OQ==
 
-postcss-selector-parser@^6.0.11:
+postcss-selector-parser@^6.0.11, postcss-selector-parser@^6.0.6:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz#2e41dc39b7ad74046e1615185185cd0b17d0c8dc"
   integrity sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==
@@ -3228,7 +3228,7 @@ postcss-selector-parser@^6.0.11:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss-value-parser@^4.2.0:
+postcss-value-parser@^4.1.0, postcss-value-parser@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
@@ -3628,12 +3628,28 @@ style-search@^0.1.0:
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==
 
+stylelint-config-css-modules@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-css-modules/-/stylelint-config-css-modules-4.1.0.tgz#b507bc074ba5bfda9f40f0be79b540db249f0c78"
+  integrity sha512-w6d552NscwvpUEaUcmq8GgWXKRv6lVHLbDj6QIHSM2vCWr83qRqRvXBJCfXDyaG/J3Zojw2inU9VvU99ZlXuUw==
+  optionalDependencies:
+    stylelint-scss "^4.2.0"
+
 stylelint-config-prettier@9.0.4:
   version "9.0.4"
   resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-9.0.4.tgz#1b1dda614d5b3ef6c1f583fa6fa55f88245eb00b"
   integrity sha512-38nIGTGpFOiK5LjJ8Ma1yUgpKENxoKSOhbDNSemY7Ep0VsJoXIW9Iq/2hSt699oB9tReynfWicTAoIHiq8Rvbg==
 
-stylelint-config-recommended@9.0.0:
+stylelint-config-recommended-scss@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-8.0.0.tgz#1c1e93e619fe2275d4c1067928d92e0614f7d64f"
+  integrity sha512-BxjxEzRaZoQb7Iinc3p92GS6zRdRAkIuEu2ZFLTxJK2e1AIcCb5B5MXY9KOXdGTnYFZ+KKx6R4Fv9zU6CtMYPQ==
+  dependencies:
+    postcss-scss "^4.0.2"
+    stylelint-config-recommended "^9.0.0"
+    stylelint-scss "^4.0.0"
+
+stylelint-config-recommended@9.0.0, stylelint-config-recommended@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-9.0.0.tgz#1c9e07536a8cd875405f8ecef7314916d94e7e40"
   integrity sha512-9YQSrJq4NvvRuTbzDsWX3rrFOzOlYBmZP+o513BJN/yfEmGSr0AxdvrWs0P/ilSpVV/wisamAHu5XSk8Rcf4CQ==
@@ -3652,6 +3668,17 @@ stylelint-processor-styled-components@1.10.0:
     "@babel/traverse" "^7.8.3"
     micromatch "^4.0.2"
     postcss "^7.0.26"
+
+stylelint-scss@^4.0.0, stylelint-scss@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/stylelint-scss/-/stylelint-scss-4.3.0.tgz#638800faf823db11fff60d537c81051fe74c90fa"
+  integrity sha512-GvSaKCA3tipzZHoz+nNO7S02ZqOsdBzMiCx9poSmLlb3tdJlGddEX/8QzCOD8O7GQan9bjsvLMsO5xiw6IhhIQ==
+  dependencies:
+    lodash "^4.17.21"
+    postcss-media-query-parser "^0.2.3"
+    postcss-resolve-nested-selector "^0.1.1"
+    postcss-selector-parser "^6.0.6"
+    postcss-value-parser "^4.1.0"
 
 stylelint@14.16.1:
   version "14.16.1"


### PR DESCRIPTION
Since we're teaching CSS Modules with Sass (scss) for the `app` directory in Next.js 13+, enable Stylelint linting for those files.