### PR TITLE
Add override to support additional file extensions

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -411,7 +411,7 @@ const config = {
     'upleveled/no-unnecessary-interpolations': 'warn',
   },
   overrides: [
-    { files: '**/*.cjs' },
+    { files: '**/*.{cjs,mjs,cts,mts,jsx}' },
     {
       files: [
         'app/**/layout.js',

--- a/index.cjs
+++ b/index.cjs
@@ -411,6 +411,7 @@ const config = {
     'upleveled/no-unnecessary-interpolations': 'warn',
   },
   overrides: [
+    { files: '**/*.cjs' },
     {
       files: [
         'app/**/layout.js',

--- a/index.cjs
+++ b/index.cjs
@@ -411,7 +411,7 @@ const config = {
     'upleveled/no-unnecessary-interpolations': 'warn',
   },
   overrides: [
-    { files: '**/*.{cjs,mjs,cts,mts,jsx}' },
+    { files: '**/*.{jsx,cjs,mjs,cts,mts}' },
     {
       files: [
         'app/**/layout.js',


### PR DESCRIPTION
With the current configuration out of the box, our eslint is ignoring .cjs, .mjs, .cts, .mts and .jsx files:

this can be tested in the following reproduction repo:

https://stackblitz.com/edit/github-7bne77?file=README.md

steps to reproduce:

1. run `pnpm eslint . --max-warnings 0 `
2. check ESLint is not running in ./index.cjs
3. run `pnpm eslint "**/*.cjs" --max-warnings 0`
4. check now the file is checked as expected

based on the [official documentation](https://eslint.org/docs/latest/use/configure/configuration-files#specifying-target-files-to-lint:~:text=If%20you%20specified,of%20overrides%20entries.):

> ESLint searches target files in the directory to lint. The target files are *.js or the files that match any of overrides entries 

so by default, .only .js files are going to be linted unles an override exists. 


This PR adds the override for .cjs, .mjs, .cts, .mts and .jsx files in order to get proper lifting there too.

## Overrides:

Based on the documentation [overrides work similarly to extends and can contain almost any property as a config object but are targeted to specific files](https://eslint.org/docs/latest/use/configure/configuration-files#specifying-target-files-to-lint:~:text=Glob%20pattern%20overrides,an%20overrides%20setting.)

so the override

```js
  overrides: [
    { files: '**/*.cjs' },
  ]
```
make all .cjs files matched by the glob and Its going to contain all the rules in the configuration. If the override contain a rule property like the following:

```js
  overrides: [
    {
      files: '**/*.cjs',
      rules: { '@typescript-eslint/no-unused-vars': "off" },
    },
  ],
```

This is going only to overrule the `@typescript-eslint/no-unused-vars` rule but any other of the rules in the configuration.

this can also be reproduced in the [repo ](https://stackblitz.com/edit/github-7bne77?file=.eslintrc.cjs,index.cjs,.gitignore) by running `pnpm eslint . --max-warnings 0` 

index.cjs contain two errors listed in the config

```js
const lol;  // no-unused-vars

const a = "hello";

if(a){  // no-unnecessary-condition
  console.log(a)
}

```

since the override turn off the ` @typescript-eslint/no-unused-vars` 

the output is:

```console
❯ pnpm eslint . --max-warnings 0 

/home/projects/github-7bne77/nestedDir/index.cjs
  5:4  warning  Unnecessary conditional, value is always truthy  @typescript-eslint/no-unnecessary-condition

✖ 1 problem (0 errors, 1 warning)

ESLint found too many warnings (maximum: 0).
```

output without rule object in the override:

```console
❯ pnpm eslint . --max-warnings 0 

/home/projects/github-7bne77/nestedDir/index.cjs
  1:7  warning  'lol' is defined but never used                  @typescript-eslint/no-unused-vars
  5:4  warning  Unnecessary conditional, value is always truthy  @typescript-eslint/no-unnecessary-condition

✖ 2 problems (0 errors, 2 warnings)

ESLint found too many warnings (maximum: 0).
```
proof that the remaining rules still apply to the files in the overrides


