### PR TITLE
Fix regex with capturing group

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -110,7 +110,7 @@ https://github.com/reactjs/reactjs.org/issues/4626#issuecomment-1117535930`,
   // Warn on nesting any invalid elements inside of <tbody>, <thead> and <tfoot> elements
   {
     selector:
-      "JSXElement[openingElement.name.name=/tbody|thead|tfoot/] > JSXElement[openingElement.name.name!='tr'][openingElement.name.name!=/^[A-Z]/]",
+      "JSXElement[openingElement.name.name=/(tbody|thead|tfoot)/] > JSXElement[openingElement.name.name!='tr'][openingElement.name.name!=/^[A-Z]/]",
     message:
       'Invalid DOM Nesting: tbody, thead and tfoot elements cannot have non-tr elements as children',
   },
@@ -118,7 +118,7 @@ https://github.com/reactjs/reactjs.org/issues/4626#issuecomment-1117535930`,
   // Warn on nesting any invalid elements inside of <tr> elements
   {
     selector:
-      "JSXElement[openingElement.name.name='tr'] > JSXElement[openingElement.name.name!=/th|td/][openingElement.name.name!=/^[A-Z]/]",
+      "JSXElement[openingElement.name.name='tr'] > JSXElement[openingElement.name.name!=/(th|td)/][openingElement.name.name!=/^[A-Z]/]",
     message:
       'Invalid DOM Nesting: tr elements cannot have elements which are not th or td elements as children',
   },

--- a/index.cjs
+++ b/index.cjs
@@ -66,19 +66,19 @@ https://github.com/reactjs/reactjs.org/issues/4626#issuecomment-1117535930`,
   // Warn on nesting <a> elements, <button> elements and framework <Link> components inside of each other
   {
     selector:
-      "JSXElement[openingElement.name.name='a'] > JSXElement[openingElement.name.name=/^a|button|Link$/]",
+      "JSXElement[openingElement.name.name='a'] > JSXElement[openingElement.name.name=/^(a|button|Link)$/]",
     message:
       'Invalid DOM Nesting: anchor elements cannot have anchor elements, button elements or Link components as children',
   },
   {
     selector:
-      "JSXElement[openingElement.name.name='button'] > JSXElement[openingElement.name.name=/^a|button|Link$/]",
+      "JSXElement[openingElement.name.name='button'] > JSXElement[openingElement.name.name=/^(a|button|Link)$/]",
     message:
       'Invalid DOM Nesting: button elements cannot have anchor elements, button elements or Link components as children',
   },
   {
     selector:
-      "JSXElement[openingElement.name.name='Link'] > JSXElement[openingElement.name.name=/^a|button|Link$/]",
+      "JSXElement[openingElement.name.name='Link'] > JSXElement[openingElement.name.name=/^(a|button|Link)$/]",
     message:
       'Invalid DOM Nesting: Link components cannot have anchor elements, button elements or Link components as children',
   },
@@ -86,7 +86,7 @@ https://github.com/reactjs/reactjs.org/issues/4626#issuecomment-1117535930`,
   // Warn on nesting of non-<li> elements inside of <ol> and <ul> elements
   {
     selector:
-      "JSXElement[openingElement.name.name=/^ol|ul$/] > JSXElement[openingElement.name.name!='li'][openingElement.name.name!=/^[A-Z]/]",
+      "JSXElement[openingElement.name.name=/^(ol|ul)$/] > JSXElement[openingElement.name.name!='li'][openingElement.name.name!=/^[A-Z]/]",
     message:
       'Invalid DOM Nesting: ol and ul elements cannot have non-li elements as children',
   },
@@ -94,7 +94,7 @@ https://github.com/reactjs/reactjs.org/issues/4626#issuecomment-1117535930`,
   // Warn on nesting common invalid elements inside of <p> elements
   {
     selector:
-      "JSXElement[openingElement.name.name='p'] > JSXElement[openingElement.name.name=/^div|h1|h2|h3|h4|h5|h6|hr|ol|p|table|ul$/]",
+      "JSXElement[openingElement.name.name='p'] > JSXElement[openingElement.name.name=/^(div|h1|h2|h3|h4|h5|h6|hr|ol|p|table|ul)$/]",
     message:
       'Invalid DOM Nesting: p elements cannot have div, h1, h2, h3, h4, h5, h6, hr, ol, p, table or ul elements as children',
   },
@@ -102,7 +102,7 @@ https://github.com/reactjs/reactjs.org/issues/4626#issuecomment-1117535930`,
   // Warn on nesting any invalid elements inside of <table> elements
   {
     selector:
-      "JSXElement[openingElement.name.name='table'] > JSXElement[openingElement.name.name!=/^caption|colgroup|tbody|tfoot|thead$/][openingElement.name.name!=/^[A-Z]/]",
+      "JSXElement[openingElement.name.name='table'] > JSXElement[openingElement.name.name!=/^(caption|colgroup|tbody|tfoot|thead)$/][openingElement.name.name!=/^[A-Z]/]",
     message:
       'Invalid DOM Nesting: table elements cannot have element which are not caption, colgroup, tbody, tfoot or thead elements as children',
   },
@@ -442,7 +442,7 @@ const config = {
           // Warn on Route Handler function without NextResponse return type annotation
           {
             selector:
-              "FunctionDeclaration[id.name=/^GET|POST|PUT|DELETE$/]:not([returnType.typeAnnotation.typeName.name='Promise'][returnType.typeAnnotation.typeParameters.params.0.typeName.name='NextResponse'][returnType.typeAnnotation.typeParameters.params.0.typeParameters.params.0]):not([returnType.typeAnnotation.typeName.name='NextResponse'][returnType.typeAnnotation.typeParameters.params.0])",
+              "FunctionDeclaration[id.name=/^(GET|POST|PUT|DELETE)$/]:not([returnType.typeAnnotation.typeName.name='Promise'][returnType.typeAnnotation.typeParameters.params.0.typeName.name='NextResponse'][returnType.typeAnnotation.typeParameters.params.0.typeParameters.params.0]):not([returnType.typeAnnotation.typeName.name='NextResponse'][returnType.typeAnnotation.typeParameters.params.0])",
             message:
               'Route Handler function missing return type annotation (eg. `async function PUT(request: NextRequest): Promise<NextResponse<AnimalResponseBodyPut>>`)',
           },


### PR DESCRIPTION
## Description

This PR adds a capturing group to the regular expression used in ESLint. Previously, the regular expression, for example, `/^div|h1|h2|h3|h4|h5|h6|hr|ol|p|table|ul$/`, caused an issue due to the missing of the capturing group when using the pipe character, resulting in individual character matching instead of the entire string. This update adds a capturing group to match any of the allowed element names.