### PR TITLE
Add TS to devDependencies in ESLint installation

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -37,9 +37,14 @@ writeFileSync(
 );
 
 const newDevDependenciesToInstall = [
-  // Fixes missing Typescript module error by adding it to devDependencies installed by ESLint
-  // This is due to pnpm not hoisting peerDependencies and their bins, leading to the error
-  // Adding Typescript ensures it's installed when running ESLint installation
+  // pnpm v8+ automatically installs peer dependencies (auto-install-peers=true
+  // is default) and `typescript` is a peer dependency of eslint-config-upleveled,
+  // but the dependencies and their bins are not hoisted, which makes ESLint (and
+  // potentially other tooling) fail to resolve TypeScript
+  //
+  // Similar issue with `stylelint` here:
+  // https://github.com/stylelint/stylelint/issues/6781#issuecomment-1506751686
+  // https://github.com/pnpm/pnpm/issues/6392
   'typescript',
 ];
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -65,7 +65,12 @@ console.log(
   `Installing ${newDevDependenciesToInstall.length} ESLint config dependencies...`,
 );
 
-execSync(`pnpm add --save-dev ${newDevDependenciesToInstall.join(' ')}`);
+execSync(
+  newDevDependenciesToInstall.length > 0
+    ? `pnpm add --save-dev ${newDevDependenciesToInstall.join(' ')}`
+    : 'pnpm install',
+  { stdio: 'inherit' },
+);
 
 console.log('✅ Done installing dependencies');
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -36,7 +36,7 @@ writeFileSync(
   JSON.stringify(projectPackageJson, null, 2) + '\n',
 );
 
-const newDevDependenciesToInstall = [];
+const newDevDependenciesToInstall = ['typescript'];
 
 if (
   // Install SafeQL dependencies in Next.js and Postgres.js projects
@@ -65,12 +65,7 @@ console.log(
   `Installing ${newDevDependenciesToInstall.length} ESLint config dependencies...`,
 );
 
-execSync(
-  newDevDependenciesToInstall.length > 0
-    ? `pnpm add --save-dev ${newDevDependenciesToInstall.join(' ')}`
-    : 'pnpm install',
-  { stdio: 'inherit' },
-);
+execSync(`pnpm add --save-dev ${newDevDependenciesToInstall.join(' ')}`);
 
 console.log('✅ Done installing dependencies');
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -36,6 +36,9 @@ writeFileSync(
   JSON.stringify(projectPackageJson, null, 2) + '\n',
 );
 
+// Fixes missing Typescript module error by adding it to devDependencies installed by ESLint
+// This is due to pnpm not hoisting peerDependencies and their bins, leading to the error
+// Adding Typescript ensures it's installed when running ESLint installation
 const newDevDependenciesToInstall = ['typescript'];
 
 if (

--- a/bin/install.js
+++ b/bin/install.js
@@ -36,10 +36,12 @@ writeFileSync(
   JSON.stringify(projectPackageJson, null, 2) + '\n',
 );
 
-// Fixes missing Typescript module error by adding it to devDependencies installed by ESLint
-// This is due to pnpm not hoisting peerDependencies and their bins, leading to the error
-// Adding Typescript ensures it's installed when running ESLint installation
-const newDevDependenciesToInstall = ['typescript'];
+const newDevDependenciesToInstall = [
+  // Fixes missing Typescript module error by adding it to devDependencies installed by ESLint
+  // This is due to pnpm not hoisting peerDependencies and their bins, leading to the error
+  // Adding Typescript ensures it's installed when running ESLint installation
+  'typescript',
+];
 
 if (
   // Install SafeQL dependencies in Next.js and Postgres.js projects


### PR DESCRIPTION
## Description

This PR adds TypeScript to the devDependencies that ESLint is installing. The purpose of this change is to fix an error that occurs when running any linting processes (including `pnpm start` in a `create-react-app`), which indicates that TypeScript is missing from the `node_modules`.

```
Error: Cannot find module 'typescript' from 
'/Users/lukas/Documents/projects/pnpm-react-color-generator/node_modules'
```

Other tooling may also expect `typescript` to be installed in `node_modules/typescript` and the bins to be available in `node_modules/.bin`

With this change, the TypeScript package will be installed automatically when running the ESLint installation.

To test the changes, I edited the code in the `eslint-config-upleveled install.js` file inside `node_modules`. Then, I ran `pnpm upleveled-eslint-install` to ensure that TypeScript is installed, and finally, I ran `pnpm start` to check that the development server is running correctly.


