### PR TITLE
Configure pnpm v8+ for Netlify

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -35,7 +35,7 @@ if (
   !projectPackageJson.packageManager
 ) {
   projectPackageJson.packageManager = 'pnpm@8.3.1';
-  console.log('✅ Added "packageManager" option to package.json');
+  console.log('✅ Configured package manager in package.json for Netlify');
 }
 
 writeFileSync(

--- a/bin/install.js
+++ b/bin/install.js
@@ -31,9 +31,11 @@ if ('next' in projectDependencies) {
   }
 }
 
-// Netlify uses an outdated version of pnpm which can cause
-// issues with peer dependencies during deployment.
-// To avoid this, we need to configure package.json to use pnpm v8+.
+// As of April 2023, Netlify uses pnpm v7, which causes peer dependencies
+// which we rely on being automatically installed to not be available
+// (pnpm v8+ sets `auto-install-peers` to true)
+//
+// TODO: Remove again when Netlify upgrades to pnpm v8+
 // https://answers.netlify.com/t/upgrade-netlify-build-to-pnpm-v8/90570
 if (
   '@upleveled/react-scripts' in projectDependencies &&

--- a/bin/install.js
+++ b/bin/install.js
@@ -33,7 +33,7 @@ if ('next' in projectDependencies) {
 
 // Netlify uses an outdated version of pnpm which can cause
 // issues with peer dependencies during deployment.
-// To avoid this, we need to configure package.json to use pnpm version 8.+.
+// To avoid this, we need to configure package.json to use pnpm v8+.
 // https://answers.netlify.com/t/upgrade-netlify-build-to-pnpm-v8/90570
 if (
   '@upleveled/react-scripts' in projectDependencies &&

--- a/bin/install.js
+++ b/bin/install.js
@@ -222,6 +222,24 @@ writeFileSync(
 
 console.log('✅ Done updating .gitignore');
 
+if (
+  '@upleveled/react-scripts' in projectDependencies &&
+  !projectPackageJson.packageManager
+) {
+  try {
+    const response = await fetch('https://registry.npmjs.org/pnpm/latest');
+    const data = await response.json();
+    projectPackageJson.packageManager = `pnpm@${data.version}`;
+    writeFileSync(
+      projectPackageJsonPath,
+      JSON.stringify(projectPackageJson, null, 2) + '\n',
+    );
+    console.log('✅ Added "packageManager" option to package.json');
+  } catch (err) {
+    // Swallow error if fetching latest pnpm version fails
+  }
+}
+
 // if ('next' in projectDependencies) {
 //   const patchesPath = join(process.cwd(), 'patches');
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -30,6 +30,13 @@ if ('next' in projectDependencies) {
     );
   }
 }
+if (
+  '@upleveled/react-scripts' in projectDependencies &&
+  !projectPackageJson.packageManager
+) {
+  projectPackageJson.packageManager = 'pnpm@8.3.1';
+  console.log('✅ Added "packageManager" option to package.json');
+}
 
 writeFileSync(
   projectPackageJsonPath,
@@ -221,24 +228,6 @@ writeFileSync(
 );
 
 console.log('✅ Done updating .gitignore');
-
-if (
-  '@upleveled/react-scripts' in projectDependencies &&
-  !projectPackageJson.packageManager
-) {
-  try {
-    const response = await fetch('https://registry.npmjs.org/pnpm/latest');
-    const data = await response.json();
-    projectPackageJson.packageManager = `pnpm@${data.version}`;
-    writeFileSync(
-      projectPackageJsonPath,
-      JSON.stringify(projectPackageJson, null, 2) + '\n',
-    );
-    console.log('✅ Added "packageManager" option to package.json');
-  } catch (err) {
-    // Swallow error if fetching latest pnpm version fails
-  }
-}
 
 // if ('next' in projectDependencies) {
 //   const patchesPath = join(process.cwd(), 'patches');

--- a/bin/install.js
+++ b/bin/install.js
@@ -30,6 +30,11 @@ if ('next' in projectDependencies) {
     );
   }
 }
+
+// Netlify uses an outdated version of pnpm which can cause
+// issues with peer dependencies during deployment.
+// To avoid this, we need to configure package.json to use pnpm version 8.+.
+// https://answers.netlify.com/t/upgrade-netlify-build-to-pnpm-v8/90570
 if (
   '@upleveled/react-scripts' in projectDependencies &&
   !projectPackageJson.packageManager


### PR DESCRIPTION
This PR adds a `packageManager` option to the `package.json` file for projects that use `@upleveled/react-scripts` and do not already have a `packageManager` specified. This option is set to the latest version of pnpm, fetched from the npm registry API. Netlify currently uses `pnpm v7`, which can cause issues with deer dependencies. Adding this option will ensure that the correct version of pnpm is used for deployment.

This is the error message when deploying on Netlify without specifying the `packageManager`: 
```
10:07:47 AM: Failed during stage 'Install dependencies': dependency_installation script returned non-zero exit 
10:07:47 AM: hint: If you want peer dependencies to be automatically installed, add "auto-install-peers=true" to an .npmrc file at the root of your project.
10:07:47 AM: hint: If you don't want pnpm to fail on peer dependency issues, add "strict-peer-dependencies=false" to an .npmrc file at the root of your project.
10:07:47 AM: Error during pnpm install
10:07:47 AM: Build was terminated: dependency_installation script returned non-zero exit code: 1
10:07:47 AM: Failing build: Failed to install dependencies
10:07:47 AM: Finished processing build request in 33.255s
```
For more details on the possibility of upgrading to the version of pnpm used in the Netlify build image, visit the following link: https://answers.netlify.com/t/upgrade-netlify-build-to-pnpm-v8/90570.