### PR TITLE
Add React types to devDependencies

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -76,7 +76,12 @@ if (
   '@upleveled/react-scripts' in projectDependencies ||
   'next' in projectDependencies
 ) {
-  newDevDependenciesToInstall.push('stylelint', 'stylelint-config-upleveled');
+  newDevDependenciesToInstall.push(
+    '@types/react',
+    '@types/react-dom',
+    'stylelint',
+    'stylelint-config-upleveled',
+  );
 }
 
 for (const projectDevDependency of Object.keys(projectDevDependencies)) {


### PR DESCRIPTION
This PR adds missing devDependencies required for React and Next.js when installing ESLint. It adds `@types/react` and `@types/react-dom` to the list of devDependencies. 

