### PR TITLE
Add type override for json_agg

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -804,7 +804,7 @@ The following environment variables are not set: ${missingEnvVars.join(', ')}
           ],
           overrides: {
             types: {
-              json: 'JsonAgg[]',
+              json: 'JsonAgg',
             },
           },
         },

--- a/index.cjs
+++ b/index.cjs
@@ -784,6 +784,11 @@ safeql: try {
               transform: '{type}[]',
             },
           ],
+          overrides: {
+            types: {
+              json: 'JsonAgg',
+            },
+          },
         },
       ],
     },

--- a/index.cjs
+++ b/index.cjs
@@ -786,7 +786,7 @@ safeql: try {
           ],
           overrides: {
             types: {
-              json: 'JsonAgg',
+              json: 'JsonAgg[]',
             },
           },
         },


### PR DESCRIPTION
Setting an override for the `json` type in SafeQL, so that we can safely use the `json_agg` aggregate function to return `json` array from SQL queries without throwing a SafeQL error according to this issue comment in SafeQL
https://github.com/ts-safeql/safeql/issues/102#issuecomment-1318322571

## When a query contains json array, SafeQl infers  type `any`
![Screenshot 2023-05-22 at 11 15 47](https://github.com/upleveled/eslint-config-upleveled/assets/74430629/5103c2a2-8ef3-4178-bf48-079eda973d8d)

![Screenshot 2023-05-22 at 11 16 40](https://github.com/upleveled/eslint-config-upleveled/assets/74430629/eba3640d-8661-4a0e-8c89-6848145b202d)
