### PR TITLE
Switch ESLint `ignores` config to .gitignore

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import next from '@next/eslint-plugin-next';
 import eslintTypescript from '@typescript-eslint/eslint-plugin';
 import typescriptParser from '@typescript-eslint/parser';
+import gitignore from 'eslint-config-flat-gitignore';
 import eslintImport from 'eslint-plugin-import';
 import jsxA11y from 'eslint-plugin-jsx-a11y';
 import jsxExpressions from 'eslint-plugin-jsx-expressions';
@@ -454,6 +455,7 @@ const eslintConfigReactAppRules = {
 
 /** @type {import('@typescript-eslint/utils/ts-eslint').FlatConfig.ConfigArray} */
 const config = [
+  gitignore(),
   {
     // Lint common extensions by default with rules above
     files: [
@@ -465,18 +467,6 @@ const config = [
       '**/*.tsx',
       '**/*.cts',
       '**/*.mts',
-    ],
-    ignores: [
-      // Next.js cache
-      '.next/**/*',
-      // Next.js builds
-      //
-      // Also `@upleveled/create-react-app` builds, until we migrate
-      // everything to Next.js
-      // https://github.com/upleveled/create-react-app/pull/2
-      // TODO: Remove this part of the comment once we migrate
-      // everything from create-react-app to Next.js
-      'build/**/*',
     ],
     languageOptions: {
       parser: typescriptParser,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-upleveled",
-  "version": "7.0.1",
+  "version": "7.1.0-0",
   "description": "UpLeveled ESLint defaults for programming in JavaScript, TypeScript, React, Next.js, Node.js, Postgres.js",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@next/eslint-plugin-next": "14.0.2",
     "@typescript-eslint/eslint-plugin": "6.11.1-alpha.20",
     "@typescript-eslint/parser": "6.11.1-alpha.20",
+    "eslint-config-flat-gitignore": "0.1.1",
     "eslint-import-resolver-typescript": "3.6.1",
     "eslint-plugin-import": "2.29.0",
     "eslint-plugin-jsx-a11y": "6.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   eslint:
     specifier: ^8.53.0
     version: 8.53.0
+  eslint-config-flat-gitignore:
+    specifier: 0.1.1
+    version: 0.1.1
   eslint-import-resolver-typescript:
     specifier: 3.6.1
     version: 3.6.1(@typescript-eslint/parser@6.11.1-alpha.20)(eslint-plugin-import@2.29.0)(eslint@8.53.0)
@@ -1488,6 +1491,12 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  /eslint-config-flat-gitignore@0.1.1:
+    resolution: {integrity: sha512-ysq0QpN63+uaxE67U0g0HeCweIpv8Ztp7yvm0nYiM2TBalRIG6KQLO5J6lAz2gkA8KVis/QsJppe+BR5VigtWQ==}
+    dependencies:
+      parse-gitignore: 2.0.0
+    dev: false
+
   /eslint-config-upleveled@7.0.1(@babel/core@7.21.0)(@types/eslint@8.44.7)(@types/node@20.9.0)(@types/react-dom@18.2.15)(@types/react@18.2.37)(eslint@8.53.0)(globals@13.23.0)(typescript@5.2.2):
     resolution: {integrity: sha512-GvUyDHpp1q3AUJxtQ4B8IwbtaKhg2qbt75NGK2wV+PniqBiOVcFO8UQaMDnQt6fsV72i6F/aVwpIh+SGPBGvdw==}
     engines: {node: '>=18.0.0'}
@@ -2886,6 +2895,11 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       callsites: 3.1.0
+
+  /parse-gitignore@2.0.0:
+    resolution: {integrity: sha512-RmVuCHWsfu0QPNW+mraxh/xjQVw/lhUCUru8Zni3Ctq3AoMhpDTq0OVdKS6iesd6Kqb7viCV3isAL43dciOSog==}
+    engines: {node: '>=14'}
+    dev: false
 
   /parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}


### PR DESCRIPTION
Switch to `.gitignore`-based ignores, by using https://github.com/antfu/eslint-config-flat-gitignore

Our existing ignores config below has entries which are already in `.gitignore`:

```js
ignores: [
  // Next.js cache
  '.next/**/*',
  // Next.js builds
  //
  // Also `@upleveled/create-react-app` builds, until we migrate
  // everything to Next.js
  // https://github.com/upleveled/create-react-app/pull/2
  // TODO: Remove this part of the comment once we migrate
  // everything from create-react-app to Next.js
  'build/**/*',
],
```

It also doesn't seem to make much sense to lint files which are in `.gitignore`. Will revisit in future if necessary.