### PR TITLE
Set "moduleDetection": "force" in tsconfig.json

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,9 +3,10 @@
   "display": "UpLeveled Node + React TSConfig",
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "module": "ESNext",
     "target": "ES2015",
+    "module": "ESNext",
     "moduleResolution": "Bundler",
+    "moduleDetection": "force",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "isolatedModules": true,


### PR DESCRIPTION
> `moduleDetection`
>
> This setting controls how TypeScript determines whether a file is a script or a module
>
> "force" - Ensures that every non-declaration file is treated as a module.

https://www.typescriptlang.org/tsconfig#:~:text=Ensures%20that%20every%20non%2Ddeclaration%20file%20is%20treated%20as%20a%20module.
