### PR TITLE
Switch module config in tsconfig.json

### DIFF
--- a/templates/node-js/tsconfig.json
+++ b/templates/node-js/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "eslint-config-upleveled/tsconfig.base.json",
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext"
+  },
   "include": [
     "**/*.ts",
     "**/*.tsx",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,7 @@
   "compilerOptions": {
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "target": "ES2015",
-    "module": "ESNext",
+    "module": "Preserve",
     "moduleResolution": "Bundler",
     "moduleDetection": "force",
     "resolveJsonModule": true,


### PR DESCRIPTION
Switch `"module"` config in `tsconfig.json`:

1. Switch `"module": "ESNext"` to `"module": "Preserve"` for bundler environments
2. Switch `"module": "ESNext"` to `"module": "NodeNext"` for Node.js
3. Switch `"moduleResolution": "Bundler"` to `"moduleResolution": "NodeNext"` for Node.js

## Reasoning

1. According to Matt Pocock, `"module": "Preserve"` more closely matches what bundlers do than `"module": "ESNext"`:
   - https://twitter.com/mattpocockuk/status/1766064573130444872
   - https://www.totaltypescript.com/tsconfig-cheat-sheet#not-transpiling-with-typescript
2. Also according to Matt Pocock, `"module": "NodeNext"` and `"moduleResolution": "NodeNext"` should be used if transpiling with `tsc` (which would be the case for Node.js projects)