### PR TITLE
Remove moduleResolution from tsconfig.json

### DIFF
--- a/templates/node-js/tsconfig.json
+++ b/templates/node-js/tsconfig.json
@@ -2,8 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "eslint-config-upleveled/tsconfig.base.json",
   "compilerOptions": {
-    "module": "NodeNext",
-    "moduleResolution": "NodeNext"
+    "module": "NodeNext"
   },
   "include": [
     "**/*.ts",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,6 @@
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "target": "ES2015",
     "module": "Preserve",
-    "moduleResolution": "Bundler",
     "moduleDetection": "force",
     "resolveJsonModule": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Remove unnecessary `moduleResolution` config, since it is automatically set to the value we want:

> It's a great day. You can forget `moduleResolution` exists, and delete it from your tsconfig.json.
>
> It's now implied by the only two valid 'module' options:
>
> "module": "preserve" -> "moduleResolution": "bundler"
> "module": "nodenext" -> "moduleResolution": "nodenext"

Source:

- https://twitter.com/mattpocockuk/status/1775138087443595689
- https://www.totaltypescript.com/tsconfig-cheat-sheet#:~:text=module%3A%20preserve%20is%20the%20best%20option%20because%20it%20most%20closely%20mimics%20how%20bundlers%20treat%20modules.%20moduleResolution%3A%20Bundler%20is%20implied%20from%20this%20option.