### PR TITLE
Switch relative path to TS 5.5 ${configDir}

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,5 +21,5 @@
     "incremental": true,
     "noUncheckedIndexedAccess": true
   },
-  "exclude": ["../../node_modules", "../../build"]
+  "exclude": ["${configDir}/node_modules", "${configDir}/build"]
 }


### PR DESCRIPTION
Closes #394

TypeScript 5.5 introduced `${configDir}`, for specifying the directory where the config is:

- https://devblogs.microsoft.com/typescript/announcing-typescript-5-5-beta/#the-configdir-template-variable-for-configuration-files
- https://github.com/microsoft/TypeScript/issues/37227
- https://github.com/microsoft/TypeScript/issues/51213
- https://github.com/microsoft/TypeScript/issues/57485
- https://github.com/microsoft/TypeScript/pull/58042

We can use this to avoid the brittle relative paths in the `tsconfig.base.json` file