### PR TITLE
Add `packageManager` to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,6 @@
   },
   "engines": {
     "node": ">=20.9.0"
-  }
+  },
+  "packageManager": "pnpm@9.1.1+sha256.9551e803dcb7a1839fdf5416153a844060c7bce013218ce823410532504ac10b"
 }


### PR DESCRIPTION
Corepack adds a new `"packageManager"` property to `package.json` since [`corepack@0.26.0`](https://github.com/nodejs/corepack/releases/tag/v0.26.0) (PR: https://github.com/nodejs/corepack/pull/413)

```bash
$ pnpm install
! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing pnpm@9.1.1+sha256.9551e803dcb7a1839fdf5416153a844060c7bce013218ce823410532504ac10b.
! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager
```