### PR TITLE
Add support for Expo with PostgreSQL

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -202,7 +202,8 @@ for (const {
     // projects
     if (
       templateFileName === 'prettier.config.js' &&
-      projectType === 'next-js-postgresql'
+      (projectType === 'next-js-postgresql' ||
+        projectType === 'expo-postgresql')
     ) {
       overwriteExistingFile = true;
     }

--- a/bin/install.js
+++ b/bin/install.js
@@ -23,16 +23,16 @@ const projectDependencies = projectPackageJson.dependencies || {};
 const projectDevDependencies = projectPackageJson.devDependencies || {};
 
 const [projectType, projectTypeTitle] =
-  'expo' in projectDependencies && 'postgres' in projectDependencies
-    ? ['expo-postgresql', 'Expo with PostgreSQL']
-    : 'postgres' in projectDependencies
-      ? ['next-js-postgresql', 'Next.js with PostgreSQL']
+  'postgres' in projectDependencies && 'next' in projectDependencies
+    ? ['next-js-postgresql', 'Next.js with PostgreSQL']
+    : 'postgres' in projectDependencies && 'expo' in projectDependencies
+      ? ['expo-postgresql', 'Expo with PostgreSQL']
       : 'next' in projectDependencies
         ? ['next-js', 'Next.js']
-        : '@upleveled/react-scripts' in projectDependencies
-          ? ['create-react-app', 'Create React App']
-          : 'expo' in projectDependencies
-            ? ['expo', 'Expo (React Native)']
+        : 'expo' in projectDependencies
+          ? ['expo', 'Expo (React Native)']
+          : '@upleveled/react-scripts' in projectDependencies
+            ? ['create-react-app', 'Create React App']
             : ['node-js', 'Node.js'];
 
 console.log(`Detected project type: ${projectTypeTitle}`);

--- a/bin/install.js
+++ b/bin/install.js
@@ -23,15 +23,17 @@ const projectDependencies = projectPackageJson.dependencies || {};
 const projectDevDependencies = projectPackageJson.devDependencies || {};
 
 const [projectType, projectTypeTitle] =
-  'postgres' in projectDependencies
-    ? ['next-js-postgresql', 'Next.js with PostgreSQL']
-    : 'next' in projectDependencies
-      ? ['next-js', 'Next.js']
-      : '@upleveled/react-scripts' in projectDependencies
-        ? ['create-react-app', 'Create React App']
-        : 'expo' in projectDependencies
-          ? ['expo', 'Expo (React Native)']
-          : ['node-js', 'Node.js'];
+  'expo' in projectDependencies && 'postgres' in projectDependencies
+    ? ['expo-postgresql', 'Expo with PostgreSQL']
+    : 'postgres' in projectDependencies
+      ? ['next-js-postgresql', 'Next.js with PostgreSQL']
+      : 'next' in projectDependencies
+        ? ['next-js', 'Next.js']
+        : '@upleveled/react-scripts' in projectDependencies
+          ? ['create-react-app', 'Create React App']
+          : 'expo' in projectDependencies
+            ? ['expo', 'Expo (React Native)']
+            : ['node-js', 'Node.js'];
 
 console.log(`Detected project type: ${projectTypeTitle}`);
 
@@ -98,7 +100,7 @@ const newDevDependenciesToInstall = [
 
 // Install Prettier and SafeQL dependencies in Postgres.js
 // projects
-if (projectType === 'next-js-postgresql') {
+if (projectType === 'next-js-postgresql' || projectType === 'expo-postgresql') {
   newDevDependenciesToInstall.push(
     '@ts-safeql/eslint-plugin',
     'libpg-query',

--- a/templates/expo-postgresql/eslint.config.js
+++ b/templates/expo-postgresql/eslint.config.js
@@ -1,0 +1,1 @@
+export { default } from 'eslint-config-upleveled';

--- a/templates/expo-postgresql/prettier.config.js
+++ b/templates/expo-postgresql/prettier.config.js
@@ -1,0 +1,35 @@
+/** @type {import('prettier').Config} */
+const prettierConfig = {
+  plugins: ['prettier-plugin-embed', 'prettier-plugin-sql'],
+  singleQuote: true,
+  trailingComma: 'all',
+};
+
+/** @type {import('prettier-plugin-embed').PrettierPluginEmbedOptions} */
+const prettierPluginEmbedConfig = {
+  embeddedSqlComments: ['sql'],
+  embeddedSqlTags: ['sql'],
+};
+
+/** @type {import('prettier-plugin-sql').SqlBaseOptions} */
+const prettierPluginSqlConfig = {
+  language: 'postgresql',
+  keywordCase: 'upper',
+  identifierCase: 'lower',
+  dataTypeCase: 'lower',
+  functionCase: 'lower',
+  // - Wrap all parenthesized expressions to new lines (eg. `INSERT` columns)
+  // - Do not wrap foreign keys (eg. `REFERENCES table_name (id)`)
+  // - Do not wrap column type expressions (eg. `VARCHAR(255)`)
+  // - Do not wrap longer field names when used alone (eg. `address_line_one`)
+  // - Do not wrap shorter expressions in function calls (eg. `avg(ratings.rating)`)
+  expressionWidth: 30,
+};
+
+const config = {
+  ...prettierConfig,
+  ...prettierPluginEmbedConfig,
+  ...prettierPluginSqlConfig,
+};
+
+export default config;

--- a/templates/expo-postgresql/tsconfig.json
+++ b/templates/expo-postgresql/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "eslint-config-upleveled/tsconfig.base.json",
+  "compilerOptions": {
+    // Based on expo/tsconfig.base.json
+    // https://github.com/expo/expo/blob/main/packages/expo/tsconfig.base.json
+    "jsx": "react-native",
+    "target": "ESNext"
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js",
+    "**/*.jsx",
+    "**/*.cjs",
+    "**/*.mjs"
+  ],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
This PR adds a new project type to UpLeveled ESLint. Previously, if a project had `postgres` installed, ESLint assumed it was a Next.js application. Now, with the use of Expo Router, we can set up PostgreSQL in an Expo React Native project. This update ensures that ESLint correctly identifies Expo projects with PostgreSQL.