### PR TITLE
Switch import assertions (`assert`) to import attributes (`with`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1105,7 +1105,7 @@ if (
 
 const packageJson = /** @type {Record<string, any>} */ (
   await import(pathToFileURL(`${process.cwd()}/package.json`).href, {
-    assert: { type: 'json' },
+    with: { type: 'json' },
   })
 );
 


### PR DESCRIPTION
> The old "import assertions" proposal has been renamed to "import attributes" with the following major changes:
>
> 1. The keyword is now `with` instead of `assert`.
> 2. Unknown assertions cause an error rather than being ignored.

- https://github.com/tc39/proposal-import-attributes/issues/6#issuecomment-1492361854
- https://github.com/v8/v8/commit/159c82c5e6392e78b9bba7161b1bed6e23758984
- https://github.com/nodejs/node/pull/50140
- https://nodejs.org/en/blog/release/v20.10.0/