### PR TITLE
Update index.js with '**/*.jsx'

### DIFF
--- a/index.js
+++ b/index.js
@@ -1083,7 +1083,7 @@ if (
   !tsconfigJson.compilerOptions.checkJs
 ) {
   configArray.push({
-    files: ['**/*.js', '**/*.mjs', '**/*.cjs'],
+    files: ['**/*.js', '**/*.mjs', '**/*.cjs', '**/*.jsx'],
     rules: {
       '@typescript-eslint/no-unsafe-member-access': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',


### PR DESCRIPTION
Prevent `Unsafe member access .attending on an `any` value.` problems being reported in `.jsx` files which are not reported with other JavaScript file extensions.

```js
const response = await fetch('http://localhost:3000/guests/1');
const updatedGuest = await response.json();
console.log(updatedGuest.attending);
```

![Screenshot 2024-09-30 at 09 41 38](https://github.com/user-attachments/assets/aaeed2ce-f8fd-4f24-a312-0de3b92f35db)
