### PR TITLE
Enforce Expo API Route response type checking

### DIFF
--- a/index.js
+++ b/index.js
@@ -1004,13 +1004,30 @@ const configArray = [
       // Warn on restricted syntax
       'no-restricted-syntax': [
         ...noRestrictedSyntaxOptions,
-        // Warn on Route Handler function without NextResponse
+        // Warn on Next.js Route Handler function without NextResponse
         // return type annotation
         {
           selector:
             "FunctionDeclaration[id.name=/^(GET|POST|PUT|DELETE)$/]:not([returnType.typeAnnotation.typeName.name='Promise'][returnType.typeAnnotation.typeArguments.params.0.typeName.name='NextResponse'][returnType.typeAnnotation.typeArguments.params.0.typeArguments.params.0]):not([returnType.typeAnnotation.typeName.name='NextResponse'][returnType.typeAnnotation.typeArguments.params.0])",
           message:
             'Route Handler function missing return type annotation (eg. `async function PUT(request: NextRequest): Promise<NextResponse<AnimalResponseBodyPut>>`)',
+        },
+      ],
+    },
+  },
+  {
+    files: ['app/**/*+api.js', 'app/**/*+api.ts'],
+    rules: {
+      // Warn on restricted syntax
+      'no-restricted-syntax': [
+        ...noRestrictedSyntaxOptions,
+        // Warn on Expo API Route function without ExpoApiResponse
+        // return type annotation
+        {
+          selector:
+            "FunctionDeclaration[id.name=/^(GET|POST|PUT|DELETE)$/]:not([returnType.typeAnnotation.typeName.name='Promise'][returnType.typeAnnotation.typeArguments.params.0.typeName.name='ExpoApiResponse'][returnType.typeAnnotation.typeArguments.params.0.typeArguments.params.0]):not([returnType.typeAnnotation.typeName.name='ExpoApiResponse'][returnType.typeAnnotation.typeArguments.params.0])",
+          message:
+            'API Route function missing return type annotation (eg. `async function PUT(request: Request): Promise<ExpoApiResponse<AnimalResponseBodyPut>>`)',
         },
       ],
     },


### PR DESCRIPTION
Closes #395

Add enforcement for Expo API Routes function return types using [the `ExpoApiResponse` type](https://github.com/upleveled/expo-example-spring-2024-atvie/pull/4/commits/98e83ec403f84e28ab454018bc92052f78a33fe5), first proposed in https://github.com/expo/expo/issues/30521