### PR TITLE
Configure Expo Router Typed Routes experiment

### DIFF
--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -19,6 +19,10 @@ if (!isPlainObject(appJson) || !isPlainObject(appJson.expo)) {
   );
 }
 
+appJson.expo.experiments ||= {};
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Set to empty object in previous line, if falsy
+appJson.expo.experiments.typedRoutes = true;
+
 appJson.expo.plugins = [
   [
     'expo-build-properties',


### PR DESCRIPTION
Configure [Expo Router Typed Routes](https://docs.expo.dev/router/reference/typed-routes) during Expo setup