### PR TITLE
Breaking: Remove Expo SDK 51 config, switch to app.config.ts

### DIFF
--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -1,6 +1,8 @@
 // Enable Expo non-default options for performance:
 //
-// 1. app.json - Convert to app.config.ts
+// 1. Convert app.json to app.config.ts for better flexibility, TypeScript support, and dynamic configuration
+//    This change is temporary until create-expo-app generates app.config.ts by default
+//    - Issue: https://github.com/expo/expo/issues/34357
 //    - https://docs.expo.dev/workflow/configuration/
 // 2. .env.development, .env.production, eas.json - Enable the new Metro resolver available starting in Expo SDK 51
 //    - https://github.com/EvanBacon/pillar-valley/commit/ede321ef7addc67e4047624aedb3e92af3cb5060

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -10,11 +10,12 @@
 //    - https://archive.ph/MG03E
 //
 // TODO: Remove when Expo enables New Architecture and new Metro resolver by default
-import { execSync } from 'node:child_process';
+import { exec } from 'node:child_process';
 import { readFile, unlink, writeFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
 import isPlainObject from 'is-plain-obj';
 
-execSync('pnpm add --save-dev prettier', { stdio: 'inherit' });
+await promisify(exec)('pnpm add --save-dev prettier');
 
 const { format } = await import('prettier');
 
@@ -75,7 +76,6 @@ easJson.build.development.extends = 'base';
 easJson.build.development.env = {
   NODE_ENV: 'development',
 };
-
 easJson.build.preview.extends = 'base';
 easJson.build.production.extends = 'base';
 

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -15,14 +15,6 @@ import { readFile, unlink, writeFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
 import isPlainObject from 'is-plain-obj';
 
-// Install Prettier to format `app.config.ts`, colocated in this script for
-// easier removal
-//
-// TODO: Remove if `create-expo-app` creates `app.config.ts` in future:
-// - https://github.com/expo/expo/issues/34357
-await promisify(exec)('pnpm add --save-dev prettier');
-const { format } = await import('prettier');
-
 const appJsonFilePath = 'app.json';
 const appJson = JSON.parse(await readFile(appJsonFilePath, 'utf8'));
 
@@ -31,6 +23,14 @@ if (!isPlainObject(appJson) || !isPlainObject(appJson.expo)) {
     'app.json either contains non-object or contains object without .expo property',
   );
 }
+
+// Install Prettier to format `app.config.ts`, colocated in this script for
+// easier removal
+//
+// TODO: Remove if `create-expo-app` creates `app.config.ts` in future:
+// - https://github.com/expo/expo/issues/34357
+await promisify(exec)('pnpm add --save-dev prettier');
+const { format } = await import('prettier');
 
 await writeFile(
   'app.config.ts',

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -7,7 +7,9 @@
 //    - https://archive.ph/MG03E
 //
 // TODO: Remove when Expo enables New Architecture and new Metro resolver by default
+import { exec } from 'node:child_process';
 import { readFile, unlink, writeFile } from 'node:fs/promises';
+import { promisify } from 'node:util';
 import isPlainObject from 'is-plain-obj';
 
 const appFilePath = 'app.json';
@@ -19,21 +21,17 @@ if (!isPlainObject(appJson) || !isPlainObject(appJson.expo)) {
   );
 }
 
-const expoConfig =
-  `import { ExpoConfig } from "expo/config";
+const expoConfig = `import { ExpoConfig } from "expo/config";
 
-const config: ExpoConfig = ${JSON.stringify(appJson.expo, null, 2)
-    .replace(/"([^"]+)":/g, '$1:')
-    .replace(/"(.*?)"/g, `'$1'`)
-    .replace(/([}\]])(\s*[}\]])/g, '$1,$2')
-    .replace(/}(\s+\])/g, '},$1')
-    .replace(/(?<!,)(\n\s*[}\]])/g, ',$1')};
+const config: ExpoConfig = ${JSON.stringify(appJson.expo, null, 2)};
 
-export default config;
-`.trim() + '\n';
+export default config;`.trim();
 
 await writeFile('app.config.ts', expoConfig, 'utf8');
 console.log('✅ Converted app.json to app.config.ts');
+
+await promisify(exec)('npx prettier --write app.config.ts');
+console.log('✅ Formatted app.config.ts with Prettier');
 
 await unlink(appFilePath);
 console.log('✅ Deleted app.json');

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -15,12 +15,12 @@ import { readFile, unlink, writeFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
 import isPlainObject from 'is-plain-obj';
 
-// Install Prettier to format app.config.ts
-// - Keeps installation colocated with its usage for easier maintenance
-// - Simplifies cleanup when Expo eventually generates app.config.ts by default
+// Install Prettier to format `app.config.ts`, colocated in this script for
+// easier removal
+//
+// TODO: Remove if `create-expo-app` creates `app.config.ts` in future:
 // - https://github.com/expo/expo/issues/34357
 await promisify(exec)('pnpm add --save-dev prettier');
-
 const { format } = await import('prettier');
 
 const appJsonFilePath = 'app.json';

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -10,38 +10,6 @@
 import { readFile, writeFile } from 'node:fs/promises';
 import isPlainObject from 'is-plain-obj';
 
-const appFilePath = 'app.json';
-const appJson = JSON.parse(await readFile(appFilePath, 'utf8'));
-
-if (!isPlainObject(appJson) || !isPlainObject(appJson.expo)) {
-  throw new Error(
-    'app.json either contains non-object or contains object without .expo property',
-  );
-}
-
-appJson.expo.experiments ||= {};
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Set to empty object in previous line, if falsy
-appJson.expo.experiments.typedRoutes = true;
-
-appJson.expo.plugins = [
-  [
-    'expo-build-properties',
-    {
-      ios: {
-        newArchEnabled: true,
-      },
-      android: {
-        newArchEnabled: true,
-      },
-    },
-  ],
-];
-
-await writeFile(appFilePath, JSON.stringify(appJson, null, 2), 'utf8');
-console.log(
-  '✅ Enabled New Architecture and typedRoutes experiment in app.json',
-);
-
 await writeFile('.env.development', 'EXPO_USE_FAST_RESOLVER=1', 'utf8');
 console.log('✅ Enabled new Metro resolver in .env.development');
 await writeFile('.env.production', 'EXPO_USE_FAST_RESOLVER=1', 'utf8');

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -20,6 +20,9 @@ if (!isPlainObject(appJson) || !isPlainObject(appJson.expo)) {
   );
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- appJson.expo.web is an object
+appJson.expo.web.output = 'server';
+
 appJson.expo.plugins = [
   [
     'expo-router',
@@ -27,11 +30,19 @@ appJson.expo.plugins = [
       origin: 'https://evanbacon.dev/',
     },
   ],
+  [
+    'expo-splash-screen',
+    {
+      image: './assets/images/splash-icon.png',
+      imageWidth: 200,
+      resizeMode: 'contain',
+      backgroundColor: '#ffffff',
+    },
+  ],
 ];
 
-appJson.expo.web.output = 'server';
-
-appJson.expo.experiments = { reactServerFunctions: true };
+// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- appJson.expo.experiments is an object
+appJson.expo.experiments.reactServerFunctions = true;
 
 await writeFile(appFilePath, JSON.stringify(appJson, null, 2), 'utf8');
 console.log('✅ Enabled Expo Router API Routes in app.json');

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -2,7 +2,6 @@
 //
 // 1. app.json - Enable API Routes and React Server Components
 //    - https://docs.expo.dev/router/reference/api-routes/
-//    - https://docs.expo.dev/guides/server-components/
 // 2. .env.development, .env.production, eas.json - Enable the new Metro resolver available starting in Expo SDK 51
 //    - https://github.com/EvanBacon/pillar-valley/commit/ede321ef7addc67e4047624aedb3e92af3cb5060
 //    - https://archive.ph/MG03E
@@ -41,11 +40,8 @@ appJson.expo.plugins = [
   ],
 ];
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- appJson.expo.experiments is an object
-appJson.expo.experiments.reactServerFunctions = true;
-
 await writeFile(appFilePath, JSON.stringify(appJson, null, 2), 'utf8');
-console.log('✅ Enabled Expo Router API Routes and RSC in app.json');
+console.log('✅ Enabled Expo Router API Routes in app.json');
 
 await writeFile('.env.development', 'EXPO_USE_FAST_RESOLVER=1', 'utf8');
 console.log('✅ Enabled new Metro resolver in .env.development');

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -1,7 +1,7 @@
 // Enable Expo non-default options for performance:
 //
-// 1. app.json - Enable New Architecture for iOS and Android
-//    - https://docs.expo.dev/guides/new-architecture/
+// 1. app.json - Enable API Routes
+//    - https://docs.expo.dev/router/reference/api-routes/
 // 2. .env.development, .env.production, eas.json - Enable the new Metro resolver available starting in Expo SDK 51
 //    - https://github.com/EvanBacon/pillar-valley/commit/ede321ef7addc67e4047624aedb3e92af3cb5060
 //    - https://archive.ph/MG03E
@@ -9,6 +9,29 @@
 // TODO: Remove when Expo enables New Architecture and new Metro resolver by default
 import { readFile, writeFile } from 'node:fs/promises';
 import isPlainObject from 'is-plain-obj';
+
+const appFilePath = 'app.json';
+const appJson = JSON.parse(await readFile(appFilePath, 'utf8'));
+
+if (!isPlainObject(appJson) || !isPlainObject(appJson.expo)) {
+  throw new Error(
+    'app.json either contains non-object or contains object without .expo property',
+  );
+}
+
+appJson.expo.plugins = [
+  [
+    'expo-router',
+    {
+      origin: 'https://evanbacon.dev/',
+    },
+  ],
+];
+
+appJson.expo.web.output = 'server';
+
+await writeFile(appFilePath, JSON.stringify(appJson, null, 2), 'utf8');
+console.log('✅ Enabled Expo Router API Routes in app.json');
 
 await writeFile('.env.development', 'EXPO_USE_FAST_RESOLVER=1', 'utf8');
 console.log('✅ Enabled new Metro resolver in .env.development');

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -27,7 +27,7 @@ if (!isPlainObject(appJson) || !isPlainObject(appJson.expo)) {
 // Install Prettier to format `app.config.ts`, colocated in this script for
 // easier removal
 //
-// TODO: Remove if `create-expo-app` creates `app.config.ts` in future:
+// TODO: Remove this if `create-expo-app` generates `app.config.ts` in future
 // - https://github.com/expo/expo/issues/34357
 await promisify(exec)('pnpm add --save-dev prettier');
 const { format } = await import('prettier');

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -47,7 +47,7 @@ export default config;`.trim(),
   ),
   'utf8',
 );
-console.log('✅ Converted and formatted app.json to app.config.ts');
+console.log('✅ Created app.config.ts');
 
 await unlink(appJsonFilePath);
 console.log('✅ Deleted app.json');

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -1,4 +1,4 @@
-// Enable Expo non-default options for performance:
+// Enable Expo non-default options for performance and consistency:
 //
 // 1. Convert app.json to app.config.ts for better flexibility, TypeScript support, and dynamic configuration
 //    This change is temporary until create-expo-app generates app.config.ts by default

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -12,7 +12,6 @@
 // TODO: Remove when Expo enables New Architecture and new Metro resolver by default
 import { readFile, unlink, writeFile } from 'node:fs/promises';
 import isPlainObject from 'is-plain-obj';
-import { format } from 'prettier';
 
 const appFilePath = 'app.json';
 const appJson = JSON.parse(await readFile(appFilePath, 'utf8'));
@@ -23,18 +22,19 @@ if (!isPlainObject(appJson) || !isPlainObject(appJson.expo)) {
   );
 }
 
-const expoConfig = `import { type ExpoConfig } from "expo/config";
+const expoConfig =
+  `import { type ExpoConfig } from "expo/config";
 
-const config: ExpoConfig = ${JSON.stringify(appJson.expo, null, 2)};
+const config: ExpoConfig = ${JSON.stringify(appJson.expo, null, 2)
+    .replace(/"([^"]+)":/g, '$1:')
+    .replace(/"(.*?)"/g, `'$1'`)
+    .replace(/([}\]])(\s*[}\]])/g, '$1,$2')
+    .replace(/}(\s+\])/g, '},$1')
+    .replace(/(?<!,)(\n\s*[}\]])/g, ',$1')};
 
-export default config;`.trim();
+export default config;`.trim() + '\n';
 
-const formattedConfig = await format(expoConfig, {
-  parser: 'typescript',
-  singleQuote: true,
-});
-
-await writeFile('app.config.ts', formattedConfig, 'utf8');
+await writeFile('app.config.ts', expoConfig, 'utf8');
 console.log('✅ Converted and formatted app.json to app.config.ts');
 
 await unlink(appFilePath);

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -15,6 +15,10 @@ import { readFile, unlink, writeFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
 import isPlainObject from 'is-plain-obj';
 
+// Add Prettier to format app.config.ts
+// Keep installation near usage for clarity and easier removal later
+// Simplifies cleanup when Expo generates app.config.ts by default
+// - https://github.com/expo/expo/issues/34357
 await promisify(exec)('pnpm add --save-dev prettier');
 
 const { format } = await import('prettier');

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -1,6 +1,6 @@
 // Enable Expo non-default options for performance:
 //
-// 1. app.json - Enable API Routes and React Server Components
+// 1. app.json - Enable API Routes
 //    - https://docs.expo.dev/router/reference/api-routes/
 // 2. .env.development, .env.production, eas.json - Enable the new Metro resolver available starting in Expo SDK 51
 //    - https://github.com/EvanBacon/pillar-valley/commit/ede321ef7addc67e4047624aedb3e92af3cb5060

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -1,9 +1,10 @@
 // Enable Expo non-default options for performance and consistency:
 //
-// 1. Convert app.json to app.config.ts for better flexibility, TypeScript support, and dynamic configuration
-//    This change is temporary until create-expo-app generates app.config.ts by default
-//    - Issue: https://github.com/expo/expo/issues/34357
-//    - https://docs.expo.dev/workflow/configuration/
+// 1. Convert app.json to app.config.ts for consistent TS language and dynamic config
+//    - https://docs.expo.dev/workflow/configuration/#dynamic-configuration
+//
+//    TODO: Remove this if `create-expo-app` generates `app.config.ts` in future
+//    - https://github.com/expo/expo/issues/34357
 // 2. .env.development, .env.production, eas.json - Enable the new Metro resolver available starting in Expo SDK 51
 //    - https://github.com/EvanBacon/pillar-valley/commit/ede321ef7addc67e4047624aedb3e92af3cb5060
 //    - https://archive.ph/MG03E

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -11,7 +11,7 @@ import { readFile, unlink, writeFile } from 'node:fs/promises';
 import isPlainObject from 'is-plain-obj';
 
 const appFilePath = 'app.json';
-const appJson = JSON.parse(await readFile('app.json', 'utf8'));
+const appJson = JSON.parse(await readFile(appFilePath, 'utf8'));
 
 if (!isPlainObject(appJson) || !isPlainObject(appJson.expo)) {
   throw new Error(

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -23,8 +23,8 @@ await promisify(exec)('pnpm add --save-dev prettier');
 
 const { format } = await import('prettier');
 
-const appFilePath = 'app.json';
-const appJson = JSON.parse(await readFile(appFilePath, 'utf8'));
+const appJsonFilePath = 'app.json';
+const appJson = JSON.parse(await readFile(appJsonFilePath, 'utf8'));
 
 if (!isPlainObject(appJson) || !isPlainObject(appJson.expo)) {
   throw new Error(
@@ -32,21 +32,24 @@ if (!isPlainObject(appJson) || !isPlainObject(appJson.expo)) {
   );
 }
 
-const expoConfig = `import { type ExpoConfig } from 'expo/config';
+await writeFile(
+  'app.config.ts',
+  await format(
+    `import { type ExpoConfig } from 'expo/config';
 
 const config: ExpoConfig = ${JSON.stringify(appJson.expo, null, 2)};
 
-export default config;`.trim();
-
-const formattedConfig = await format(expoConfig, {
-  parser: 'typescript',
-  singleQuote: true,
-});
-
-await writeFile('app.config.ts', formattedConfig, 'utf8');
+export default config;`.trim(),
+    {
+      parser: 'typescript',
+      singleQuote: true,
+    },
+  ),
+  'utf8',
+);
 console.log('✅ Converted and formatted app.json to app.config.ts');
 
-await unlink(appFilePath);
+await unlink(appJsonFilePath);
 console.log('✅ Deleted app.json');
 
 await writeFile('.env.development', 'EXPO_USE_FAST_RESOLVER=1', 'utf8');

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -1,7 +1,8 @@
 // Enable Expo non-default options for performance:
 //
-// 1. app.json - Enable API Routes
+// 1. app.json - Enable API Routes and React Server Components
 //    - https://docs.expo.dev/router/reference/api-routes/
+//    - https://docs.expo.dev/guides/server-components/
 // 2. .env.development, .env.production, eas.json - Enable the new Metro resolver available starting in Expo SDK 51
 //    - https://github.com/EvanBacon/pillar-valley/commit/ede321ef7addc67e4047624aedb3e92af3cb5060
 //    - https://archive.ph/MG03E
@@ -29,6 +30,8 @@ appJson.expo.plugins = [
 ];
 
 appJson.expo.web.output = 'server';
+
+appJson.expo.experiments = { reactServerFunctions: true };
 
 await writeFile(appFilePath, JSON.stringify(appJson, null, 2), 'utf8');
 console.log('✅ Enabled Expo Router API Routes in app.json');

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -15,9 +15,9 @@ import { readFile, unlink, writeFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
 import isPlainObject from 'is-plain-obj';
 
-// Add Prettier to format app.config.ts
-// Keep installation near usage for clarity and easier removal later
-// Simplifies cleanup when Expo generates app.config.ts by default
+// Install Prettier to format app.config.ts
+// - Keeps installation colocated with its usage for easier maintenance
+// - Simplifies cleanup when Expo eventually generates app.config.ts by default
 // - https://github.com/expo/expo/issues/34357
 await promisify(exec)('pnpm add --save-dev prettier');
 

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -45,7 +45,7 @@ appJson.expo.plugins = [
 appJson.expo.experiments.reactServerFunctions = true;
 
 await writeFile(appFilePath, JSON.stringify(appJson, null, 2), 'utf8');
-console.log('✅ Enabled Expo Router API Routes in app.json');
+console.log('✅ Enabled Expo Router API Routes and RSC in app.json');
 
 await writeFile('.env.development', 'EXPO_USE_FAST_RESOLVER=1', 'utf8');
 console.log('✅ Enabled new Metro resolver in .env.development');

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -39,7 +39,7 @@ await writeFile(
 
 const config: ExpoConfig = ${JSON.stringify(appJson.expo, null, 2)};
 
-export default config;`.trim(),
+export default config;`,
     {
       parser: 'typescript',
       singleQuote: true,

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -80,6 +80,7 @@ easJson.build.development.extends = 'base';
 easJson.build.development.env = {
   NODE_ENV: 'development',
 };
+
 easJson.build.preview.extends = 'base';
 easJson.build.production.extends = 'base';
 

--- a/bin/expo-setup.js
+++ b/bin/expo-setup.js
@@ -23,7 +23,7 @@ const expoConfig =
   `import { ExpoConfig } from "expo/config";
 
 const config: ExpoConfig = ${JSON.stringify(appJson.expo, null, 2)
-    .replace(/"([^\"]+)":/g, '$1:')
+    .replace(/"([^"]+)":/g, '$1:')
     .replace(/"(.*?)"/g, `'$1'`)
     .replace(/([}\]])(\s*[}\]])/g, '$1,$2')
     .replace(/}(\s+\])/g, '},$1')

--- a/bin/install.js
+++ b/bin/install.js
@@ -363,6 +363,20 @@ writeFileSync(
 
 console.log('✅ Done updating .gitignore');
 
+if (projectType === 'expo' || projectType === 'expo-postgresql') {
+  console.log('Running Expo setup script...');
+  try {
+    const expoSetupPath = join(
+      dirname(fileURLToPath(import.meta.url)),
+      'expo-setup.js',
+    );
+    execSync(`node ${expoSetupPath}`, { stdio: 'inherit' });
+    console.log('✅ Done running Expo setup script');
+  } catch (error) {
+    console.error('❌ Failed to run Expo setup script', error);
+  }
+}
+
 // Commented out in case we need to patch Next.js again in the
 // future
 // ```

--- a/bin/install.js
+++ b/bin/install.js
@@ -363,20 +363,6 @@ writeFileSync(
 
 console.log('✅ Done updating .gitignore');
 
-if (projectType === 'expo' || projectType === 'expo-postgresql') {
-  console.log('Running Expo setup script...');
-  try {
-    const expoSetupPath = join(
-      dirname(fileURLToPath(import.meta.url)),
-      'expo-setup.js',
-    );
-    execSync(`node ${expoSetupPath}`, { stdio: 'inherit' });
-    console.log('✅ Done running Expo setup script');
-  } catch (error) {
-    console.error('❌ Failed to run Expo setup script', error);
-  }
-}
-
 // Commented out in case we need to patch Next.js again in the
 // future
 // ```


### PR DESCRIPTION
Issue https://github.com/upleveled/courses/issues/3000

Follow up PR 
- https://github.com/upleveled/courses/pull/2925

Breaking change: the new config introduced in this PR is SDK 52 configuration for the New Architecture, so this should only be used with Expo SDK 52+

This PR updates the project configuration to align with changes introduced in Expo SDK 52. With SDK 52, the extra configuration steps required for SDK 51 are no longer needed. Running `pnpm create expo-app@latest .` now initializes the `app.json` file with:

- `expo.newArchEnabled = true`
- `expo.experiments.typedRoutes = true`

Additionally, we switch from `app.json` to `app.config.ts` to make [the config](https://docs.expo.dev/workflow/configuration/) more dynamic, add TS support, and make it easier to manage environment-specific settings.

