### PR TITLE
Configure strict-dep-builds to fail on pnpm v10 ignored build scripts

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -376,7 +376,8 @@ try {
 
 if (!npmrcContentLines.includes('strict-dep-builds=true')) {
   console.log('Updating .npmrc...');
-  npmrcContentLines.push(`# Fail on pnpm ignored build scripts https://github.com/pnpm/pnpm/pull/9071
+  npmrcContentLines.push(`# Fail on pnpm ignored build scripts
+# - https://github.com/pnpm/pnpm/pull/9071
 strict-dep-builds=true`);
   writeFileSync(
     npmrcPath,

--- a/bin/install.js
+++ b/bin/install.js
@@ -363,6 +363,30 @@ writeFileSync(
 
 console.log('✅ Done updating .gitignore');
 
+const npmrcPath = join(process.cwd(), '.npmrc');
+
+/** @type {string[]} */
+let npmrcContentLines = [];
+
+try {
+  npmrcContentLines = readFileSync(npmrcPath, 'utf-8').split('\n');
+} catch {
+  // Swallow error in case .npmrc doesn't exist yet
+}
+
+if (!npmrcContentLines.includes('strict-dep-builds=true')) {
+  console.log('Updating .npmrc...');
+  npmrcContentLines.push(`# Fail on pnpm ignored build scripts https://github.com/pnpm/pnpm/pull/9071
+strict-dep-builds=true`);
+  writeFileSync(
+    npmrcPath,
+    npmrcContentLines.join('\n') +
+      // Add trailing newline if last line is not empty
+      (npmrcContentLines.at(-1) === '' ? '' : '\n'),
+  );
+  console.log('✅ Done updating .npmrc');
+}
+
 // Commented out in case we need to patch Next.js again in the
 // future
 // ```


### PR DESCRIPTION
[pnpm v10 blocks lifecycle scripts by default](https://socket.dev/blog/pnpm-10-0-0-blocks-lifecycle-scripts-by-default), which can lead to hard-to-debug problems:

```bash
$ pnpm install

...

╭ Warning ───────────────────────────────────────────────────────────────────────────────────╮
│                                                                                            │
│   Ignored build scripts: bcrypt.                                                           │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.   │
│                                                                                            │
╰────────────────────────────────────────────────────────────────────────────────────────────╯

# Warning message above, student may ignore this (exit code 0)

$ pnpm build

...

Cannot find module '.../bcrypt_lib.node'
```

Configure [the new pnpm v10.3.0 `strict-dep-builds` setting](https://github.com/pnpm/pnpm/pull/9071/#issuecomment-2650192097) to fail with a non-zero exit code when any build scripts for dependencies have been ignored, in order to surface problems in CI before they occur:

```bash
$ pnpm install

...

 ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: esbuild

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.

# Error message above is more visually prominent and fails on CI (non-zero exit code)
```