### PR TITLE
Update lib entry from `ES2022` to `ES2024`

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,7 +13,7 @@
     "verbatimModuleSyntax": true,
 
     // Standard library
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
 
     // Output
     "target": "ES2022",


### PR DESCRIPTION
Switch `tsconfig.json` `lib` entry from `ES2022` to `ES2024`, to [allow APIs like `Object.groupBy()`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-7.html#support-for---target-es2024-and---lib-es2024)

Perplexity Deep Research found that 65% of ES2024 is currently a part of Baseline 2024, which is acceptable for student projects:

- https://www.perplexity.ai/search/are-all-features-of-es2024-a-p-7pH_0O_qT22opTe_yeO50A