### PR TITLE
Disallow expression sequences in parentheses

### DIFF
--- a/index.js
+++ b/index.js
@@ -298,7 +298,17 @@ const eslintConfigReactAppRules = {
   'no-script-url': 'warn',
   'no-self-assign': 'warn',
   'no-self-compare': 'warn',
-  'no-sequences': 'warn',
+  // Warn on expression sequences (multiple expressions chained
+  // together with comma operators)
+  // - https://eslint.org/docs/latest/rules/no-sequences
+  'no-sequences': [
+    'warn',
+    {
+      // Warn on expression sequences in parentheses
+      // - https://eslint.org/docs/latest/rules/no-sequences#allowinparentheses
+      allowInParentheses: false,
+    },
+  ],
   'no-shadow-restricted-names': 'warn',
   'no-sparse-arrays': 'warn',
   'no-template-curly-in-string': 'warn',


### PR DESCRIPTION
Until this PR, expression sequences yielded warnings (line 1) unless they were wrapped in parentheses (line 2):

```ts
a(), b(); // ⚠️ Unexpected use of comma operator. eslint (no-sequences)
(a(), b()); // ✅
```

This pattern is however often an error, so this PR makes the expression sequences inside parentheses also yield warnings:

```ts
a(), b(); // ⚠️ Unexpected use of comma operator. eslint (no-sequences)
(a(), b()); // ⚠️ Unexpected use of comma operator. eslint (no-sequences)
```