### PR TITLE
Allow unrs-resolver build scripts for pnpm

### DIFF
--- a/__tests__/package.json
+++ b/__tests__/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "update-config-version": "pnpm add --save-dev eslint-config-upleveled@latest && pnpm upleveled-eslint-install"
+    "update-config-version": "pnpm add --save-dev eslint-config-upleveled@latest --allow-build=unrs-resolver && pnpm upleveled-eslint-install"
   },
   "dependencies": {
     "next": "^15.0.0"

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ UpLeveled ESLint defaults for programming in JavaScript, TypeScript, React, Next
 To add ESLint configuration to a project, install the dependencies and add the config files:
 
 ```sh
-pnpm add --save-dev eslint-config-upleveled@latest
+pnpm add --save-dev eslint-config-upleveled@latest --allow-build=unrs-resolver
 pnpm upleveled-eslint-install
 ```
 


### PR DESCRIPTION
Allow `unrs-resolver` build scripts for pnpm, to avoid `Ignored build scripts: unrs-resolver` messages as shown below

```bash
➜  p mkdir a && cd a
➜  a pnpm init
Wrote to /Users/k/p/a/package.json
...
➜  a pnpm add --save-dev eslint-config-upleveled@latest
 WARN  1 deprecated subdependencies found: @babel/plugin-proposal-private-methods@7.18.6
Packages: +381
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 405, reused 345, downloaded 42, added 381, done

devDependencies:
+ eslint-config-upleveled 9.2.4

 ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: unrs-resolver

Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

Contrast this with using [the `--allow-build=<pkg name>` option on `pnpm add`](https://pnpm.io/cli/add#--allow-build), which adds a new file `pnpm-workspace.yaml` with a new element in the `onlyBuiltDependencies` config:

```bash
➜  a pnpm add --save-dev eslint-config-upleveled@latest --allow-build=unrs-resolver
 WARN  1 deprecated subdependencies found: @babel/plugin-proposal-private-methods@7.18.6
Packages: +381
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 405, reused 387, downloaded 0, added 381, done
node_modules/.pnpm/unrs-resolver@1.11.1/node_modules/unrs-resolver: Running postinstall script, done in 274ms

devDependencies:
+ eslint-config-upleveled 9.2.4

Done in 3.9s using pnpm v10.13.1
➜  a l
total 272
drwxr-xr-x@  6 k  staff   192B Jul 11 10:16 .
drwxr-xr-x  96 k  staff   3.0K Jul 11 10:15 ..
drwxr-xr-x@  7 k  staff   224B Jul 11 10:16 node_modules
-rw-r--r--@  1 k  staff   329B Jul 11 10:16 package.json
-rw-r--r--@  1 k  staff   126K Jul 11 10:16 pnpm-lock.yaml
-rw-r--r--@  1 k  staff    41B Jul 11 10:16 pnpm-workspace.yaml
➜  a cat pnpm-workspace.yaml
onlyBuiltDependencies:
  - unrs-resolver
```