### PR TITLE
Switch to hardcoded Node.js version + Renovate to avoid action lag

### DIFF
--- a/.github/workflows/lint-check-types-test.yml
+++ b/.github/workflows/lint-check-types-test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: '22.18.0'
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm eslint . --max-warnings 0


### PR DESCRIPTION
`actions/setup-node` has multiple days / weeks of lag behind new Node.js versions:

- https://github.com/actions/setup-node/issues/940
- https://github.com/actions/setup-node/issues/1236

Switch back to `actions/setup-node`, but with a hardcoded version number which is upgraded instead through Renovate bot PRs.

- [x] Switch to hardcoded Node.js version