### PR TITLE
Migrate rest of rules to eslint-plugin-react-x, -dom, -naming-convention

### DIFF
--- a/index.js
+++ b/index.js
@@ -985,6 +985,9 @@ const configArray = [
       // Error on passing children to void elements
       // https://eslint-react.xyz/docs/rules/dom-no-void-elements-with-children
       'react-dom/no-void-elements-with-children': 'error',
+      // Warn on duplicate props in JSX
+      // https://eslint-react.xyz/docs/rules/jsx-no-duplicate-props
+      'react-x/jsx-no-duplicate-props': 'warn',
       // Warn if a `key` is set to an `index`
       // https://eslint-react.xyz/docs/rules/no-array-index-key
       'react-x/no-array-index-key': 'error',
@@ -1003,9 +1006,6 @@ const configArray = [
       // Error on direct mutation of state
       // https://eslint-react.xyz/docs/rules/no-direct-mutation-state
       'react-x/no-direct-mutation-state': 'warn',
-      // Warn on duplicate props in JSX
-      // https://eslint-react.xyz/docs/rules/jsx-no-duplicate-props
-      'react-x/jsx-no-duplicate-props': 'warn',
       // Disallow potentially falsey string and number values in
       // logical && expressions
       // https://eslint-react.xyz/docs/rules/no-leaked-conditional-rendering

--- a/index.js
+++ b/index.js
@@ -450,7 +450,7 @@ const eslintConfigReactAppRules = {
   // ```
   // 'react/jsx-no-duplicate-props': 'warn',
   // ```
-  // Disabled because replacement rule react-x/no-unsafe-target-blank configured below
+  // Disabled because replacement rule react-dom/no-unsafe-target-blank configured below
   // ```
   // 'react/jsx-no-target-blank': 'warn',
   // ```

--- a/index.js
+++ b/index.js
@@ -490,8 +490,9 @@ const eslintConfigReactAppRules = {
   // 'react/no-typos': 'error',
   // 'react/require-render-return': 'error',
   // ```
-  // Cannot migrate to eslint-plugin-react-x yet, since there is no replacement rule for non-TS environments like MDX
-  // https://github.com/Rel1cx/eslint-react/issues/85
+  // TODO: Migrate to eslint-plugin-react-x, once there is a
+  // replacement rule for non-TS environments like MDX
+  // https://github.com/Rel1cx/eslint-react/issues/85#issuecomment-3148421342
   'react/style-prop-object': [
     'warn',
     {

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ import react from 'eslint-plugin-react';
 import reactCompiler from 'eslint-plugin-react-compiler';
 import reactDom from 'eslint-plugin-react-dom';
 import reactHooks from 'eslint-plugin-react-hooks';
+import reactNamingConvention from 'eslint-plugin-react-naming-convention';
 import reactX from 'eslint-plugin-react-x';
 import security from 'eslint-plugin-security';
 import sonarjs from 'eslint-plugin-sonarjs';
@@ -437,14 +438,28 @@ const eslintConfigReactAppRules = {
   // ```
 
   // https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules
-  'react/forbid-foreign-prop-types': ['warn', { allowInPropTypes: true }],
+  // Disabled because of obsolescence of the rule (has to do with propTypes)
+  // ```
+  // 'react/forbid-foreign-prop-types': ['warn', { allowInPropTypes: true }],
+  // ```
   // Disabled because replacement rule react-x/no-comment-textnodes configured below
   // ```
   // 'react/jsx-no-comment-textnodes': 'warn',
   // ```
-  'react/jsx-no-duplicate-props': 'warn',
-  'react/jsx-no-target-blank': 'warn',
-  'react/jsx-no-undef': 'error',
+  // Disabled because replacement rule react-x/jsx-no-duplicate-props configured below
+  // ```
+  // 'react/jsx-no-duplicate-props': 'warn',
+  // ```
+  // Disabled because replacement rule react-x/no-unsafe-target-blank configured below
+  // ```
+  // 'react/jsx-no-target-blank': 'warn',
+  // ```
+  // Disable because typescript-eslint parser + ESLint built-in rule no-undef replace this
+  // https://github.com/jsx-eslint/eslint-plugin-react/pull/3941
+  // ```
+  // 'react/jsx-no-undef': 'error',
+  // ```
+  // TODO: Migrate to https://eslint.style/rules/jsx-pascal-case
   'react/jsx-pascal-case': [
     'warn',
     {
@@ -452,7 +467,10 @@ const eslintConfigReactAppRules = {
       ignore: [],
     },
   ],
-  'react/no-danger-with-children': 'warn',
+  // Disable because replacement rule react-dom/no-dangerously-set-innerhtml-with-children configured below
+  // ```
+  // 'react/no-danger-with-children': 'warn',
+  // ```
   // Disabled because of undesirable warnings See
   // https://github.com/facebook/create-react-app/issues/5204 for
   // blockers until its re-enabled
@@ -463,9 +481,17 @@ const eslintConfigReactAppRules = {
   // ```
   // 'react/no-direct-mutation-state': 'warn',
   // ```
-  'react/no-is-mounted': 'warn',
-  'react/no-typos': 'error',
-  'react/require-render-return': 'error',
+  // Disabled because of obsolescence of the rule (createReactClass is very uncommon)
+  // ```
+  // 'react/no-is-mounted': 'warn',
+  // ```
+  // Disabled because of obsolescence of the rule (relates to class components)
+  // ```
+  // 'react/no-typos': 'error',
+  // 'react/require-render-return': 'error',
+  // ```
+  // Cannot migrate to eslint-plugin-react-x yet, since there is no replacement rule for non-TS environments like MDX
+  // https://github.com/Rel1cx/eslint-react/issues/85
   'react/style-prop-object': [
     'warn',
     {
@@ -543,6 +569,7 @@ const configArray = [
       'react-compiler': reactCompiler,
       'react-dom': reactDom,
       'react-hooks': reactHooks,
+      'react-naming-convention': reactNamingConvention,
       'react-x': reactX,
       react: fixupPluginRules(react),
       security,
@@ -904,51 +931,41 @@ const configArray = [
       // https://github.com/eslint/eslint/blob/main/docs/src/rules/prefer-promise-reject-errors.md
       'prefer-promise-reject-errors': 'warn',
       // Warn about state variable and setter names which are not
-      // symmetrically named
-      // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/hook-use-state.md
-      'react/hook-use-state': 'warn',
+      // destructured or symmetrically named
+      // https://eslint-react.xyz/docs/rules/naming-convention-use-state
+      'react-naming-convention/use-state': 'warn',
       // Error on missing sandbox attribute on iframes (good
       // security practice)
-      // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/iframe-missing-sandbox.md
-      'react/iframe-missing-sandbox': 'error',
+      // https://eslint-react.xyz/docs/rules/dom-no-missing-iframe-sandbox
+      'react-dom/no-missing-iframe-sandbox': 'error',
       // Warn about unnecessary curly braces around props and
       // string literal children
       // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-curly-brace-presence.md
+      // TODO: Migrate to https://eslint.style/rules/jsx-curly-brace-presence
       'react/jsx-curly-brace-presence': [
         'warn',
         { props: 'never', children: 'never', propElementValues: 'always' },
       ],
-      // Error on missing or incorrect `key` props in maps in JSX
-      // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-key.md
-      'react/jsx-key': [
-        'error',
-        {
-          checkFragmentShorthand: true,
-          checkKeyMustBeforeSpread: true,
-          warnOnDuplicates: true,
-        },
-      ],
+      // Error on missing `key` prop in React elements
+      // https://eslint-react.xyz/docs/rules/no-missing-key
+      'react-x/no-missing-key': 'error',
+      // Error on duplicate `key` props in React elements
+      // https://eslint-react.xyz/docs/rules/no-duplicate-key
+      'react-x/no-duplicate-key': 'error',
       // Disallow React being marked as unused
-      // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md
-      'react/jsx-uses-react': 'warn',
-      // Error on invalid HTML attributes (only `rel` as of March
-      // 2022)
-      // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-invalid-html-attribute.md
-      'react/no-invalid-html-attribute': 'error',
-      // Error on unused React prop types
-      // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md
-      'react/no-unused-prop-types': 'warn',
-      // Disable rule because the new JSX transform in React 17,
-      // Next.js and Gatsby no longer requires the import.
-      // https://github.com/jsx-eslint/eslint-plugin-react/issues/2440#issuecomment-683433266
-      'react/react-in-jsx-scope': 'off',
+      // https://eslint-react.xyz/docs/rules/jsx-uses-react
+      'react-x/jsx-uses-react': 'warn',
       // Warn about components that have a closing tag but no
       // children
       // https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md
+      // TODO: Migrate to https://eslint.style/rules/jsx-self-closing-comp
       'react/self-closing-comp': 'warn',
       // Error on code which is problematic for the React Compiler
       // https://github.com/facebook/react/tree/main/compiler/packages/eslint-plugin-react-compiler
       'react-compiler/react-compiler': 'error',
+      // Error on usage of dangerouslySetInnerHTML with children
+      // https://eslint-react.xyz/docs/rules/dom-no-dangerously-set-innerhtml-with-children
+      'react-dom/no-dangerously-set-innerhtml-with-children': 'error',
       // Error on usage of ReactDOM.findDOMNode()
       // https://eslint-react.xyz/docs/rules/dom-no-find-dom-node
       'react-dom/no-find-dom-node': 'error',
@@ -961,6 +978,9 @@ const configArray = [
       // Warn on usage of ReactDOM.renderToNodeStream()
       // https://eslint-react.xyz/docs/rules/dom-no-render-return-value
       'react-dom/no-render-return-value': 'warn',
+      // Error on usage of target="_blank" without rel="noreferrer noopener"
+      // https://eslint-react.xyz/docs/rules/dom-no-unsafe-target-blank
+      'react-dom/no-unsafe-target-blank': 'error',
       // Error on passing children to void elements
       // https://eslint-react.xyz/docs/rules/dom-no-void-elements-with-children
       'react-dom/no-void-elements-with-children': 'error',
@@ -982,6 +1002,9 @@ const configArray = [
       // Error on direct mutation of state
       // https://eslint-react.xyz/docs/rules/no-direct-mutation-state
       'react-x/no-direct-mutation-state': 'warn',
+      // Warn on duplicate props in JSX
+      // https://eslint-react.xyz/docs/rules/jsx-no-duplicate-props
+      'react-x/jsx-no-duplicate-props': 'warn',
       // Disallow potentially falsey string and number values in
       // logical && expressions
       // https://eslint-react.xyz/docs/rules/no-leaked-conditional-rendering
@@ -1064,7 +1087,7 @@ const configArray = [
       // 2. Prevent false positives in @react-three/fiber
       //    - https://github.com/jsx-eslint/eslint-plugin-react/issues/3423
       //    - https://github.com/Rel1cx/eslint-react/issues/846
-      'react/no-unknown-property': ['warn', { ignore: ['css'] }],
+      'react-dom/no-unknown-property': ['warn', { ignore: ['css'] }],
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
   "devDependencies": {
     "@typescript-eslint/utils": "8.38.0",
     "eslint-config-upleveled": "9.2.6",
+    "eslint-plugin-react-naming-convention": "1.52.3",
     "prettier": "3.6.2",
     "prettier-plugin-embed": "0.5.0",
     "prettier-plugin-sql": "0.19.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       eslint-config-upleveled:
         specifier: 9.2.6
         version: 9.2.6(@babel/core@7.26.8)(@types/node@24.1.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(@typescript-eslint/utils@8.38.0(eslint@9.31.0)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.31.0)(globals@16.3.0)(typescript@5.8.3)
+      eslint-plugin-react-naming-convention:
+        specifier: 1.52.3
+        version: 1.52.3(eslint@9.31.0)(typescript@5.8.3)
       prettier:
         specifier: 3.6.2
         version: 3.6.2
@@ -1085,6 +1088,16 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+
+  eslint-plugin-react-naming-convention@1.52.3:
+    resolution: {integrity: sha512-sfemWPC9VX5T7TVJk6OKQkTux8pnyVIwBOZbDntWnfCqV6B74MIvY2nGr9TEn8DFVWbMoTxVQY0MGlREcrbZsA==}
+    engines: {node: '>=18.18.0'}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: ^4.9.5 || ^5.3.3
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   eslint-plugin-react-x@1.52.3:
     resolution: {integrity: sha512-Sds4CXHtdgaCdzoypcY3DSshS0JtK2Eh+QbpUAPUqs0UWQ3qtQKxY0nntTSYeF+GXDfOdAYDkl/8+VFpHQwIKg==}
@@ -2240,9 +2253,6 @@ packages:
   zod@4.0.14:
     resolution: {integrity: sha512-nGFJTnJN6cM2v9kXL+SOBq3AtjQby3Mv5ySGFof5UGRHrRioSJ5iG680cYNjE/yWk671nROcpPj4hAS8nyLhSw==}
 
-  zod@4.0.5:
-    resolution: {integrity: sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==}
-
 snapshots:
 
   '@ampproject/remapping@2.3.0':
@@ -2458,7 +2468,7 @@ snapshots:
       '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.8.3)
       '@typescript-eslint/utils': 8.38.0(eslint@9.31.0)(typescript@5.8.3)
       string-ts: 2.2.1
-      ts-pattern: 5.7.1
+      ts-pattern: 5.8.0
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -2489,7 +2499,7 @@ snapshots:
       '@typescript-eslint/types': 8.38.0
       '@typescript-eslint/utils': 8.38.0(eslint@9.31.0)(typescript@5.8.3)
       birecord: 0.1.1
-      ts-pattern: 5.7.1
+      ts-pattern: 5.8.0
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -2522,8 +2532,8 @@ snapshots:
     dependencies:
       '@eslint-react/eff': 1.52.3
       '@typescript-eslint/utils': 8.38.0(eslint@9.31.0)(typescript@5.8.3)
-      ts-pattern: 5.7.1
-      zod: 4.0.5
+      ts-pattern: 5.8.0
+      zod: 4.0.14
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -2545,8 +2555,8 @@ snapshots:
       '@eslint-react/eff': 1.52.3
       '@eslint-react/kit': 1.52.3(eslint@9.31.0)(typescript@5.8.3)
       '@typescript-eslint/utils': 8.38.0(eslint@9.31.0)(typescript@5.8.3)
-      ts-pattern: 5.7.1
-      zod: 4.0.5
+      ts-pattern: 5.8.0
+      zod: 4.0.14
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -2572,7 +2582,7 @@ snapshots:
       '@typescript-eslint/types': 8.38.0
       '@typescript-eslint/utils': 8.38.0(eslint@9.31.0)(typescript@5.8.3)
       string-ts: 2.2.1
-      ts-pattern: 5.7.1
+      ts-pattern: 5.8.0
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -3484,6 +3494,26 @@ snapshots:
   eslint-plugin-react-hooks@5.2.0(eslint@9.31.0):
     dependencies:
       eslint: 9.31.0
+
+  eslint-plugin-react-naming-convention@1.52.3(eslint@9.31.0)(typescript@5.8.3):
+    dependencies:
+      '@eslint-react/ast': 1.52.3(eslint@9.31.0)(typescript@5.8.3)
+      '@eslint-react/core': 1.52.3(eslint@9.31.0)(typescript@5.8.3)
+      '@eslint-react/eff': 1.52.3
+      '@eslint-react/kit': 1.52.3(eslint@9.31.0)(typescript@5.8.3)
+      '@eslint-react/shared': 1.52.3(eslint@9.31.0)(typescript@5.8.3)
+      '@eslint-react/var': 1.52.3(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/scope-manager': 8.38.0
+      '@typescript-eslint/type-utils': 8.38.0(eslint@9.31.0)(typescript@5.8.3)
+      '@typescript-eslint/types': 8.38.0
+      '@typescript-eslint/utils': 8.38.0(eslint@9.31.0)(typescript@5.8.3)
+      eslint: 9.31.0
+      string-ts: 2.2.1
+      ts-pattern: 5.8.0
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-react-x@1.52.3(eslint@9.31.0)(ts-api-utils@2.1.0(typescript@5.8.3))(typescript@5.8.3):
     dependencies:
@@ -4847,5 +4877,3 @@ snapshots:
   zod@3.25.71: {}
 
   zod@4.0.14: {}
-
-  zod@4.0.5: {}


### PR DESCRIPTION
Continuation of migration from #530

Follow the equivalent mapping in https://github.com/Rel1cx/eslint-react/issues/85 and the `eslint-plugin-react-x` rules in https://eslint-react.xyz/docs/rules/overview to migrate rest of `eslint-plugin-react` rules with equivalents to `eslint-plugin-react-x`, `eslint-plugin-react-dom`, `eslint-plugin-react-naming-convention`

Rules without an equivalent in `eslint-plugin-react-x`, `eslint-plugin-react-dom`, `eslint-plugin-react-naming-convention` will need to be migrated to ESLint Stylistic

- [x] Migrate all `eslint-plugin-react` rules with equivalents to `eslint-plugin-react-x`, `eslint-plugin-react-dom`, `eslint-plugin-react-naming-convention`
- [x] Add TODOs for remaining 3 unmigrated `eslint-plugin-react` rules