### PR TITLE
Migrate `react-hooks/react-compiler` to split up rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -976,10 +976,63 @@ const configArray = [
       // Warn on promise rejection without Error object
       // - https://github.com/eslint/eslint/blob/main/docs/src/rules/prefer-promise-reject-errors.md
       'prefer-promise-reject-errors': 'warn',
-      // Error on code which is problematic for the React
-      // Compiler
-      // - https://github.com/facebook/react/tree/main/compiler/packages/eslint-plugin-react-compiler
-      'react-hooks/react-compiler': 'error',
+      // Error on component or hook factory functions
+      // (problematic for the React Compiler)
+      // https://react.dev/reference/eslint-plugin-react-hooks/lints/component-hook-factories
+      'react-hooks/component-hook-factories': 'error',
+      // Error on invalid React Compiler configuration
+      // (problematic for the React Compiler)
+      // https://react.dev/reference/eslint-plugin-react-hooks/lints/config
+      'react-hooks/config': 'error',
+      // Error on try/catch usage around elements or use()
+      // (problematic for the React Compiler)
+      // https://react.dev/reference/eslint-plugin-react-hooks/lints/error-boundaries
+      'react-hooks/error-boundaries': 'error',
+      // Error on invalid React Compiler gating configuration
+      // (problematic for the React Compiler)
+      // https://react.dev/reference/eslint-plugin-react-hooks/lints/gating
+      'react-hooks/gating': 'error',
+      // Error on assignment/mutation of globals during render
+      // (problematic for the React Compiler)
+      // https://react.dev/reference/eslint-plugin-react-hooks/lints/globals
+      'react-hooks/globals': 'error',
+      // Error on mutation of props, state and other immutable
+      // values (problematic for the React Compiler)
+      // https://react.dev/reference/eslint-plugin-react-hooks/lints/immutability
+      'react-hooks/immutability': 'error',
+      // Error on missing dependencies in useMemo and useCallback
+      // (problematic for the React Compiler)
+      // https://react.dev/reference/eslint-plugin-react-hooks/lints/preserve-manual-memoization
+      'react-hooks/preserve-manual-memoization': 'error',
+      // Error on calling known-impure functions like
+      // Math.random() and Date.now() (problematic for the React
+      // Compiler)
+      // https://react.dev/reference/eslint-plugin-react-hooks/lints/purity
+      'react-hooks/purity': 'error',
+      // Error on reading or writing of refs during render
+      // (problematic for the React Compiler)
+      // https://react.dev/reference/eslint-plugin-react-hooks/lints/refs
+      'react-hooks/refs': 'error',
+      // Error on calling setState synchronously in an effect
+      // (problematic for the React Compiler)
+      // https://react.dev/reference/eslint-plugin-react-hooks/lints/set-state-in-effect
+      'react-hooks/set-state-in-effect': 'error',
+      // Error on calling setState during render
+      // (problematic for the React Compiler)
+      // https://react.dev/reference/eslint-plugin-react-hooks/lints/set-state-in-render
+      'react-hooks/set-state-in-render': 'error',
+      // Error on dynamically-recreated components
+      // (problematic for the React Compiler)
+      // https://react.dev/reference/eslint-plugin-react-hooks/lints/static-components
+      'react-hooks/static-components': 'error',
+      // Error on syntax unsupported by the React Compiler
+      // (problematic for the React Compiler)
+      // https://react.dev/reference/eslint-plugin-react-hooks/lints/unsupported-syntax
+      'react-hooks/unsupported-syntax': 'error',
+      // Error on useMemo without a return value
+      // (problematic for the React Compiler)
+      // https://react.dev/reference/eslint-plugin-react-hooks/lints/use-memo
+      'react-hooks/use-memo': 'error',
       // Error on usage of dangerouslySetInnerHTML with children
       // - https://eslint-react.xyz/docs/rules/dom-no-dangerously-set-innerhtml-with-children
       'react-dom/no-dangerously-set-innerhtml-with-children': 'error',

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-jsx-a11y": "6.10.2",
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-dom": "2.0.0-next.187",
-    "eslint-plugin-react-hooks": "6.0.0-rc1",
+    "eslint-plugin-react-hooks": "6.0.0-rc.2",
     "eslint-plugin-react-naming-convention": "2.0.0-next.187",
     "eslint-plugin-react-x": "2.0.0-next.187",
     "eslint-plugin-security": "3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: 2.0.0-next.187
         version: 2.0.0-next.187(eslint@9.36.0)(typescript@5.9.2)
       eslint-plugin-react-hooks:
-        specifier: 6.0.0-rc1
-        version: 6.0.0-rc1(eslint@9.36.0)
+        specifier: 6.0.0-rc.2
+        version: 6.0.0-rc.2(eslint@9.36.0)
       eslint-plugin-react-naming-convention:
         specifier: 2.0.0-next.187
         version: 2.0.0-next.187(eslint@9.36.0)(typescript@5.9.2)
@@ -220,6 +220,13 @@ packages:
     resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/plugin-proposal-private-methods@7.18.6':
+    resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/plugin-transform-private-methods@7.27.1':
     resolution: {integrity: sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==}
@@ -1195,6 +1202,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  eslint-plugin-react-hooks@6.0.0-rc.2:
+    resolution: {integrity: sha512-2cnFkQl2xld2BgKDtxLSd/JqkpZHBXZKcz+ZurfiQ7GECzMckIddJN5PZyWach3MN4h/CjwfqPigAtYxInXtuw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
 
   eslint-plugin-react-hooks@6.0.0-rc1:
     resolution: {integrity: sha512-I4ntWyjqgGemGtOU85FUdVo00h0i0Y5xvQ7a8EVxyzjOZsxXaxvkKBcYoXbP97QDvDjMzY/nGIvfdB/WRLTGxQ==}
@@ -2520,6 +2533,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.2
 
+  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.26.8)':
+    dependencies:
+      '@babel/core': 7.26.8
+      '@babel/helper-create-class-features-plugin': 7.27.1(@babel/core@7.26.8)
+      '@babel/helper-plugin-utils': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-private-methods@7.27.1(@babel/core@7.26.8)':
     dependencies:
       '@babel/core': 7.26.8
@@ -3782,6 +3803,18 @@ snapshots:
       ts-pattern: 5.8.0
     optionalDependencies:
       typescript: 5.9.2
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-plugin-react-hooks@6.0.0-rc.2(eslint@9.36.0):
+    dependencies:
+      '@babel/core': 7.26.8
+      '@babel/parser': 7.28.0
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.26.8)
+      eslint: 9.36.0
+      hermes-parser: 0.25.1
+      zod: 3.25.71
+      zod-validation-error: 3.4.0(zod@3.25.71)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
The `react-hooks/react-compiler` rule was split up into separate rules to offer clearer feedback to developers:

- https://github.com/facebook/react/pull/34117#issuecomment-3344189761

Migrate to all of the new rules listed as available in the RC section of [the `eslint-plugin-react-hooks` docs page](https://react.dev/reference/eslint-plugin-react-hooks), except for [`incompatible-library`](https://react.dev/reference/eslint-plugin-react-hooks/lints/incompatible-library), because this rule is not yet available:

- https://github.com/facebook/react/issues/34632