### PR TITLE
Switch --allow-build to pnpm-workspace.yaml edit before install

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  # Add summary to walkthrough instead of PR description
+  high_level_summary_in_walkthrough: true
+  # Disable useless fortune
+  in_progress_fortune: false
+  # Disable useless poem
+  poem: false
+
+chat:
+  # Disable useless ASCII art or emojis in chat responses
+  art: false

--- a/bin/install.js
+++ b/bin/install.js
@@ -210,6 +210,8 @@ for (const projectDevDependency of Object.keys(projectDevDependencies)) {
   }
 }
 
+updatePnpmWorkspaceYaml();
+
 if (newDevDependenciesToInstall.length > 0) {
   console.log(
     `Installing ${newDevDependenciesToInstall.length} ESLint config ${
@@ -217,8 +219,6 @@ if (newDevDependenciesToInstall.length > 0) {
     }: ${newDevDependenciesToInstall.join(', ')}`,
   );
 }
-
-updatePnpmWorkspaceYaml();
 
 execSync(
   newDevDependenciesToInstall.length > 0

--- a/bin/install.js
+++ b/bin/install.js
@@ -448,10 +448,10 @@ function updatePnpmWorkspaceYaml() {
   // Work around `--allow-build` bug by programmatically setting
   // `allowBuild` in `pnpm-workspace.yaml`
   // - https://github.com/pnpm/pnpm/issues/13872#issuecomment-5281712949
-  doc.setIn(['allowBuilds', 'unrs-resolver'], true);
   if (newDevDependenciesToInstall.includes('@ts-safeql/eslint-plugin')) {
     doc.setIn(['allowBuilds', 'esbuild'], true);
   }
+  doc.setIn(['allowBuilds', 'unrs-resolver'], true);
 
   const minimumReleaseAgeKey = doc.createNode('minimumReleaseAge');
   minimumReleaseAgeKey.commentBefore =

--- a/bin/install.js
+++ b/bin/install.js
@@ -218,6 +218,8 @@ if (newDevDependenciesToInstall.length > 0) {
   );
 }
 
+updatePnpmWorkspaceYaml();
+
 execSync(
   newDevDependenciesToInstall.length > 0
     ? `pnpm add --save-dev ${newDevDependenciesToInstall.join(' ')}`
@@ -428,45 +430,60 @@ if (gitignoreChanged) {
   console.log('✅ Done updating .gitignore');
 }
 
-const pnpmWorkspaceYamlPath = join(process.cwd(), 'pnpm-workspace.yaml');
+function updatePnpmWorkspaceYaml() {
+  const pnpmWorkspaceYamlPath = join(process.cwd(), 'pnpm-workspace.yaml');
 
-/** @type {string} */
-let pnpmWorkspaceYamlContent = '';
+  /** @type {string} */
+  let pnpmWorkspaceYamlContent = '';
 
-try {
-  pnpmWorkspaceYamlContent = readFileSync(pnpmWorkspaceYamlPath, 'utf8');
-} catch {
-  // Swallow error in case pnpm-workspace.yaml doesn't exist yet
-}
+  try {
+    pnpmWorkspaceYamlContent = readFileSync(pnpmWorkspaceYamlPath, 'utf8');
+  } catch {
+    // Swallow error in case pnpm-workspace.yaml doesn't exist
+    // yet
+  }
 
-const doc = parseDocument(pnpmWorkspaceYamlContent);
+  const doc = parseDocument(pnpmWorkspaceYamlContent);
 
-const minimumReleaseAgeKey = doc.createNode('minimumReleaseAge');
-minimumReleaseAgeKey.commentBefore =
-  `# Prevents installation of packages newer than 7 days
+  // Work around `--allow-build` bug by programmatically setting
+  // `allowBuild` in `pnpm-workspace.yaml`
+  // - https://github.com/pnpm/pnpm/issues/13872#issuecomment-5281712949
+  doc.setIn(['allowBuilds', 'unrs-resolver'], true);
+  if (newDevDependenciesToInstall.includes('@ts-safeql/eslint-plugin')) {
+    doc.setIn(['allowBuilds', 'esbuild'], true);
+  }
+
+  const minimumReleaseAgeKey = doc.createNode('minimumReleaseAge');
+  minimumReleaseAgeKey.commentBefore =
+    `# Prevents installation of packages newer than 7 days
 # to mitigate supply chain risks
 # - https://pnpm.io/settings#minimumreleaseage`.replaceAll(/^#/gm, '');
 
-doc.setIn([minimumReleaseAgeKey], doc.createNode(10080));
-doc.setIn(
-  ['minimumReleaseAgeExclude'],
-  doc.createNode([
-    '@upleveled/*',
-    'eslint-config-upleveled',
-    'stylelint-config-upleveled',
-  ]),
-);
+  doc.setIn([minimumReleaseAgeKey], doc.createNode(10080));
+  doc.setIn(
+    ['minimumReleaseAgeExclude'],
+    doc.createNode([
+      '@upleveled/*',
+      'eslint-config-upleveled',
+      'stylelint-config-upleveled',
+    ]),
+  );
 
-const strictDepBuildsKey = doc.createNode('strictDepBuilds');
-strictDepBuildsKey.commentBefore = `# Fail on pnpm ignored build scripts
+  const strictDepBuildsKey = doc.createNode('strictDepBuilds');
+  strictDepBuildsKey.commentBefore = `# Fail on pnpm ignored build scripts
 # - https://pnpm.io/settings#strictdepbuilds`.replaceAll(/^#/gm, '');
-doc.setIn([strictDepBuildsKey], doc.createNode(true));
+  doc.setIn([strictDepBuildsKey], doc.createNode(true));
 
-const updatedPnpmWorkspaceYamlContent = String(doc);
-if (updatedPnpmWorkspaceYamlContent !== pnpmWorkspaceYamlContent) {
-  console.log('Updating pnpm-workspace.yaml...');
-  writeFileSync(pnpmWorkspaceYamlPath, updatedPnpmWorkspaceYamlContent, 'utf8');
-  console.log('✅ Done updating pnpm-workspace.yaml');
+  const updatedPnpmWorkspaceYamlContent = String(doc);
+  if (updatedPnpmWorkspaceYamlContent !== pnpmWorkspaceYamlContent) {
+    console.log('Updating pnpm-workspace.yaml...');
+    writeFileSync(
+      pnpmWorkspaceYamlPath,
+      updatedPnpmWorkspaceYamlContent,
+      'utf8',
+    );
+    console.log('✅ Done updating pnpm-workspace.yaml');
+  }
 }
 
 // Commented out in case we need to patch Next.js again in the

--- a/readme.md
+++ b/readme.md
@@ -9,8 +9,8 @@ UpLeveled ESLint defaults for programming in JavaScript, TypeScript, React, Next
 To add ESLint configuration to a project, install the dependencies and add the config files:
 
 ```sh
-pnpm add --save-dev eslint-config-upleveled@latest --allow-build=esbuild --allow-build=unrs-resolver
-pnpm upleveled-eslint-install
+pnpm add --save-dev eslint-config-upleveled@latest
+node node_modules/eslint-config-upleveled/bin/install.js
 ```
 
 <!--


### PR DESCRIPTION
Switch `--allow-build` in the install commands to earlier parsing of `pnpm-workspace.yaml` to update `allowBuilds` before `pnpm install`

- [x] Parse `pnpm-workspace.yaml` and make updates before `pnpm install`
- [x] Switch `--allow-build=esbuild` to `yaml` update of `allowBuilds['esbuild'] = true` conditionally if the `@ts-safeql/eslint-plugin` dependency will be installed (Postgres.js project)
- [x] Switch `--allow-build=esbuild` to `yaml` update of `allowBuilds['unrs-resolver'] = true`
- [x] Switch `pnpm upleveled-eslint-install` to `node node_modules/eslint-config-upleveled/bin/install.js` to avoid `ERR_PNPM_IGNORED_BUILDS` error (pnpm will throw this for every subcommand until builds are approved or ignored explicitly)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Installer setup now automatically configures required dependency build permissions.
  * Existing workspace settings are preserved during installation, including release-age and dependency build controls.
  * Setup handles projects with and without a workspace configuration file.

* **Documentation**
  * Updated setup instructions to use the latest ESLint configuration package and its bundled installer.
  * Removed obsolete build-approval options and installation commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->