### PR TITLE
Downgrade to TypeScript v6 to avoid typescript-eslint error

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -211,9 +211,9 @@ for (const projectDevDependency of Object.keys(projectDevDependencies)) {
   //
   // Remove dependency if project dependency uses ^ or ~ version
   // ranges ending in the exact version specified in
-  // newDevDependenciesToInstall, because pnpm will not install
-  // the exact version if a range is already installed, even with
-  // --save-exact:
+  // newDevDependenciesToInstall, because `pnpm add` will not
+  // replace the range in `package.json` with an exact version,
+  // even with `--save-exact`:
   //
   // - https://github.com/pnpm/pnpm/issues/6398#issuecomment-5314388945
   // - https://github.com/pnpm/pnpm/issues/8300

--- a/bin/install.js
+++ b/bin/install.js
@@ -78,7 +78,8 @@ if (projectPackageJson.type !== 'module') {
   );
 }
 
-const newDevDependenciesToInstall = [
+/** @type {Record<string, string>} */
+const newDevDependenciesToInstall = {
   // Add types for any usage of Node.js built-in modules
   //
   // To avoid confusing problems like eg.
@@ -86,7 +87,7 @@ const newDevDependenciesToInstall = [
   // Node.js projects with `any` type of `argv` imported from
   // `node:process`
   // https://typescript-eslint.io/rules/restrict-template-expressions/
-  '@types/node',
+  '@types/node': 'latest',
 
   // Install `eslint` at top level to avoid pnpm "Conflicting
   // peer dependencies" error with mismatching transitive
@@ -154,7 +155,7 @@ const newDevDependenciesToInstall = [
   //
   // - https://github.com/upleveled/eslint-config-upleveled/pull/421
   // - https://github.com/ts-safeql/safeql/issues/258
-  'eslint',
+  eslint: 'latest',
 
   // The VS Code Prettier extension uses Prettier v2 internally,
   // but Preflight uses the latest Prettier version, which causes
@@ -162,7 +163,7 @@ const newDevDependenciesToInstall = [
   // https://github.com/prettier/prettier-vscode/pull/3069#issuecomment-1817589047
   // https://github.com/prettier/prettier-vscode/issues/3298
   // https://github.com/upleveled/preflight/issues/429
-  'prettier',
+  prettier: 'latest',
 
   // pnpm v8+ automatically installs peer dependencies
   // (auto-install-peers=true is default) and `typescript` is a
@@ -175,19 +176,18 @@ const newDevDependenciesToInstall = [
   // https://github.com/stylelint/stylelint/issues/6781#issuecomment-1506751686
   // https://github.com/pnpm/pnpm/issues/6392
   //
-  // FIXME: Remove the @6 version once TypeScript 7 is supported
-  'typescript@6',
-];
+  // FIXME: Remove the @6.0.3 version once TypeScript 7 is
+  // supported in eslint-config-upleveled
+  typescript: '6.0.3',
+};
 
 // Install Prettier and SafeQL dependencies in Postgres.js
 // projects
 if (projectType === 'next-js-postgresql' || projectType === 'expo-postgresql') {
-  newDevDependenciesToInstall.push(
-    '@ts-safeql/eslint-plugin',
-    'libpg-query',
-    'prettier-plugin-embed',
-    'prettier-plugin-sql',
-  );
+  newDevDependenciesToInstall['@ts-safeql/eslint-plugin'] = 'latest';
+  newDevDependenciesToInstall['libpg-query'] = 'latest';
+  newDevDependenciesToInstall['prettier-plugin-embed'] = 'latest';
+  newDevDependenciesToInstall['prettier-plugin-sql'] = 'latest';
 }
 
 if (
@@ -195,36 +195,42 @@ if (
   projectType === 'next-js' ||
   projectType === 'next-js-postgresql'
 ) {
-  newDevDependenciesToInstall.push(
-    '@types/react',
-    '@types/react-dom',
-    'stylelint',
-    'stylelint-config-upleveled',
-  );
+  newDevDependenciesToInstall['@types/react'] = 'latest';
+  newDevDependenciesToInstall['@types/react-dom'] = 'latest';
+  newDevDependenciesToInstall['stylelint'] = 'latest';
+  newDevDependenciesToInstall['stylelint-config-upleveled'] = 'latest';
 }
 
 for (const projectDevDependency of Object.keys(projectDevDependencies)) {
-  if (newDevDependenciesToInstall.includes(projectDevDependency)) {
-    newDevDependenciesToInstall.splice(
-      newDevDependenciesToInstall.indexOf(projectDevDependency),
-      1,
-    );
+  if (projectDevDependency in newDevDependenciesToInstall) {
+    delete newDevDependenciesToInstall[projectDevDependency];
   }
 }
 
+const newDevDependenciesToInstallKeys = Object.keys(
+  newDevDependenciesToInstall,
+);
+const newDevDependenciesToInstallPackageSpecs = Object.entries(
+  newDevDependenciesToInstall,
+).map(([packageName, version]) =>
+  version === 'latest' ? packageName : `${packageName}@${version}`,
+);
+
 updatePnpmWorkspaceYaml();
 
-if (newDevDependenciesToInstall.length > 0) {
+if (newDevDependenciesToInstallKeys.length > 0) {
   console.log(
-    `Installing ${newDevDependenciesToInstall.length} ESLint config ${
-      newDevDependenciesToInstall.length === 1 ? 'dependency' : 'dependencies'
-    }: ${newDevDependenciesToInstall.join(', ')}`,
+    `Installing ${newDevDependenciesToInstallKeys.length} ESLint config ${
+      newDevDependenciesToInstallKeys.length === 1
+        ? 'dependency'
+        : 'dependencies'
+    }: ${newDevDependenciesToInstallPackageSpecs.join(', ')}`,
   );
 }
 
 execSync(
-  newDevDependenciesToInstall.length > 0
-    ? `pnpm add --save-dev ${newDevDependenciesToInstall.join(' ')}`
+  newDevDependenciesToInstallKeys.length > 0
+    ? `pnpm add --save-dev ${newDevDependenciesToInstallPackageSpecs.join(' ')}`
     : 'pnpm install',
   { stdio: 'inherit' },
 );
@@ -450,7 +456,7 @@ function updatePnpmWorkspaceYaml() {
   // Work around `--allow-build` bug by programmatically setting
   // `allowBuild` in `pnpm-workspace.yaml`
   // - https://github.com/pnpm/pnpm/issues/13872#issuecomment-5281712949
-  if (newDevDependenciesToInstall.includes('@ts-safeql/eslint-plugin')) {
+  if (newDevDependenciesToInstallKeys.includes('@ts-safeql/eslint-plugin')) {
     doc.setIn(['allowBuilds', 'esbuild'], true);
   }
   doc.setIn(['allowBuilds', 'unrs-resolver'], true);

--- a/bin/install.js
+++ b/bin/install.js
@@ -236,14 +236,16 @@ if (newDevDependenciesToInstallKeys.length > 0) {
         : 'dependencies'
     }: ${newDevDependenciesToInstallPackageSpecs.join(', ')}...`,
   );
+  execSync(
+    `pnpm add --save-dev ${newDevDependenciesToInstallPackageSpecs.join(' ')}`,
+    { stdio: 'inherit' },
+  );
+} else {
+  console.log(
+    'Installing to apply pnpm settings changes in pnpm-workspace.yaml...',
+  );
+  execSync('pnpm install', { stdio: 'inherit' });
 }
-
-execSync(
-  newDevDependenciesToInstallKeys.length > 0
-    ? `pnpm add --save-dev ${newDevDependenciesToInstallPackageSpecs.join(' ')}`
-    : 'pnpm install',
-  { stdio: 'inherit' },
-);
 
 console.log('✅ Done installing dependencies');
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -176,7 +176,7 @@ const newDevDependenciesToInstall = {
   // https://github.com/stylelint/stylelint/issues/6781#issuecomment-1506751686
   // https://github.com/pnpm/pnpm/issues/6392
   //
-  // FIXME: Remove the @6.0.3 version once TypeScript 7 is
+  // FIXME: Remove the 6.0.3 version once TypeScript 7 is
   // supported in eslint-config-upleveled
   typescript: '6.0.3',
 };

--- a/bin/install.js
+++ b/bin/install.js
@@ -234,7 +234,7 @@ if (newDevDependenciesToInstallKeys.length > 0) {
       newDevDependenciesToInstallKeys.length === 1
         ? 'dependency'
         : 'dependencies'
-    }: ${newDevDependenciesToInstallPackageSpecs.join(', ')}`,
+    }: ${newDevDependenciesToInstallPackageSpecs.join(', ')}...`,
   );
 }
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -174,7 +174,9 @@ const newDevDependenciesToInstall = [
   // Similar issue with `stylelint` here:
   // https://github.com/stylelint/stylelint/issues/6781#issuecomment-1506751686
   // https://github.com/pnpm/pnpm/issues/6392
-  'typescript',
+  //
+  // FIXME: Remove the @6 version once TypeScript 7 is supported
+  'typescript@6',
 ];
 
 // Install Prettier and SafeQL dependencies in Postgres.js

--- a/bin/install.js
+++ b/bin/install.js
@@ -384,16 +384,12 @@ for (const {
     }
   }
 
-  try {
-    cpSync(templateFilePath, filePathInProject);
-    console.log(
-      `Copied ${templateFileName}${
-        overwriteExistingFile ? ' (existing file overwritten)' : ''
-      }`,
-    );
-  } catch (err) {
-    console.error('err', err);
-  }
+  cpSync(templateFilePath, filePathInProject);
+  console.log(
+    `Copied ${templateFileName}${
+      overwriteExistingFile ? ' (existing file overwritten)' : ''
+    }`,
+  );
 }
 
 console.log('✅ Done copying config files');

--- a/bin/install.js
+++ b/bin/install.js
@@ -201,8 +201,18 @@ if (
   newDevDependenciesToInstall['stylelint-config-upleveled'] = 'latest';
 }
 
+// Skip installation if the project dependencies already include:
+// 1. the new dependency's package name
+// 2. the new dependency's exact version, if an exact version is
+//    specified in newDevDependenciesToInstall ('latest' skips
+//    for any version)
 for (const projectDevDependency of Object.keys(projectDevDependencies)) {
-  if (projectDevDependency in newDevDependenciesToInstall) {
+  if (
+    projectDevDependency in newDevDependenciesToInstall &&
+    (newDevDependenciesToInstall[projectDevDependency] === 'latest' ||
+      newDevDependenciesToInstall[projectDevDependency] ===
+        projectDevDependencies[projectDevDependency])
+  ) {
     delete newDevDependenciesToInstall[projectDevDependency];
   }
 }

--- a/bin/install.js
+++ b/bin/install.js
@@ -207,6 +207,29 @@ if (
 //    specified in newDevDependenciesToInstall ('latest' skips
 //    for any version)
 for (const projectDevDependency of Object.keys(projectDevDependencies)) {
+  // Work around pnpm bug:
+  //
+  // Remove dependency if project dependency uses ^ or ~ version
+  // ranges ending in the exact version specified in
+  // newDevDependenciesToInstall, because pnpm will not install
+  // the exact version if a range is already installed, even with
+  // --save-exact:
+  //
+  // - https://github.com/pnpm/pnpm/issues/6398#issuecomment-5314388945
+  // - https://github.com/pnpm/pnpm/issues/8300
+  if (
+    projectDevDependency in newDevDependenciesToInstall &&
+    newDevDependenciesToInstall[projectDevDependency] !==
+      projectDevDependencies[projectDevDependency] &&
+    newDevDependenciesToInstall[projectDevDependency] ===
+      projectDevDependencies[projectDevDependency]?.replace(/^[\^~]/, '')
+  ) {
+    console.log(
+      `Removing ${projectDevDependency}@${projectDevDependencies[projectDevDependency]} to install exact version ${newDevDependenciesToInstall[projectDevDependency]}...`,
+    );
+    execSync(`pnpm remove ${projectDevDependency}`, { stdio: 'inherit' });
+  }
+
   if (
     projectDevDependency in newDevDependenciesToInstall &&
     (newDevDependenciesToInstall[projectDevDependency] === 'latest' ||

--- a/bin/install.js
+++ b/bin/install.js
@@ -203,9 +203,9 @@ if (
 
 // Skip installation if the project dependencies already include:
 // 1. the new dependency's package name
-// 2. the new dependency's exact version, if an exact version is
-//    specified in newDevDependenciesToInstall ('latest' skips
-//    for any version)
+// 2. if an exact version is specified in
+//    newDevDependenciesToInstall: the new dependency's exact
+//    version ('latest' skips for any version)
 for (const projectDevDependency of Object.keys(projectDevDependencies)) {
   // Work around pnpm bug:
   //


### PR DESCRIPTION
TypeScript v7 causes errors when used with `typescript-eslint`, because [it does not ship with an API](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/#running-side-by-side-with-typescript-6.0):

```bash
$ pnpm eslint . --max-warnings 0
Oops! Something went wrong! :(

ESLint: 9.39.5

TypeError: Cannot read properties of undefined (reading 'Cjs')
    at Object.<anonymous> (/Users/k/p/a/node_modules/.pnpm/@typescript-eslint+typescript-estree@8.56.1_supports-color@8.1.1_typescript@7.0.2/node_modules/@typescript-eslint/
    typescript-estree/dist/create-program/shared.js:59:18)
    at Module._compile (node:internal/modules/cjs/loader:1761:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1893:10)
    at Module.load (node:internal/modules/cjs/loader:1481:32)
    at Module._load (node:internal/modules/cjs/loader:1281:12)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:245:24)
    at Module.require (node:internal/modules/cjs/loader:1504:12)
    at require (node:internal/modules/helpers:152:16)
    at Object.<anonymous> (/Users/k/p/a/node_modules/.pnpm/@typescript-eslint+typescript-estree@8.56.1_supports-color@8.1.1_typescript@7.0.2/node_modules/@typescript-eslint/
    typescript-estree/dist/create-program/getWatchProgramsForProjects.js:45:18)
```

Downgrade to TypeScript v6 to avoid this.

- [x] Switch `newDevDependenciesToInstall` from an array to an object
- [x] Add `6.0.3` version for `typescript` dependency to be installed
- [x] Add `'latest'` versions for all other dependencies
- [x] For dependencies with exact versions, skip dependencies if exact version already installed
- [x] Work around pnpm bug [`pnpm/pnpm#8300`](https://github.com/pnpm/pnpm/issues/8300) and [`pnpm/pnpm#6398`](https://github.com/pnpm/pnpm/issues/6398#issuecomment-5314388945)  where `pnpm add --save-exact` doesn't update to an exact pinned version in `package.json`: for any dependency with an exact version, first remove project dependency versions with `^` or `~` ranges and then re-add them with the exact version
- [x] Add `console.log()` for `pnpm install` after `pnpm-workspace.yaml` adjustment
- [x] Remove `try/catch` with `console.error('err', ...)`