### PR TITLE
Remove unused Babel parser, testing-library plugin, ts-api-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "postpublish": "cd __tests__ && pnpm update-config-version"
   },
   "dependencies": {
-    "@babel/eslint-parser": "7.29.7",
     "@eslint/compat": "2.1.0",
     "@next/eslint-plugin-next": "16.3.3",
     "@stylistic/eslint-plugin": "5.10.0",
@@ -52,13 +51,11 @@
     "eslint-plugin-react-x": "2.13.0",
     "eslint-plugin-security": "4.0.1",
     "eslint-plugin-sonarjs": "4.2.0",
-    "eslint-plugin-testing-library": "7.16.2",
     "eslint-plugin-unicorn": "73.0.0",
     "eslint-plugin-upleveled": "2.1.15",
     "is-plain-obj": "4.1.0",
     "sort-package-json": "3.6.1",
     "strip-json-comments": "5.0.3",
-    "ts-api-utils": "2.5.0",
     "yaml": "^2.8.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,18 +8,15 @@ importers:
 
   .:
     dependencies:
-      '@babel/eslint-parser':
-        specifier: 7.29.7
-        version: 7.29.7(@babel/core@7.28.4)(eslint@9.39.2)
       '@eslint/compat':
         specifier: 2.1.0
-        version: 2.1.0(eslint@9.39.2)
+        version: 2.1.0
       '@next/eslint-plugin-next':
         specifier: 16.3.3
-        version: 16.3.3(eslint@9.39.2)
+        version: 16.3.3
       '@stylistic/eslint-plugin':
         specifier: 5.10.0
-        version: 5.10.0(eslint@9.39.2)
+        version: 5.10.0
       '@types/node':
         specifier: '>=26.4.0'
         version: 26.4.0
@@ -31,10 +28,10 @@ importers:
         version: 19.2.5(@types/react@19.2.18)
       '@typescript-eslint/eslint-plugin':
         specifier: 8.68.0
-        version: 8.68.0(@typescript-eslint/parser@8.68.0(eslint@9.39.2)(typescript@6.0.3))(eslint@9.39.2)(typescript@6.0.3)
+        version: 8.68.0(@typescript-eslint/parser@8.68.0(typescript@6.0.3))(typescript@6.0.3)
       '@typescript-eslint/parser':
         specifier: 8.68.0
-        version: 8.68.0(eslint@9.39.2)(typescript@6.0.3)
+        version: 8.68.0(typescript@6.0.3)
       comment-json:
         specifier: 5.0.0
         version: 5.0.0
@@ -43,43 +40,40 @@ importers:
         version: 9.39.2
       eslint-config-flat-gitignore:
         specifier: 2.4.0
-        version: 2.4.0(eslint@9.39.2)
+        version: 2.4.0
       eslint-import-resolver-typescript:
         specifier: 4.4.5
-        version: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.68.0(eslint@9.39.2)(typescript@6.0.3))(eslint@9.39.2))(eslint@9.39.2)
+        version: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.68.0(typescript@6.0.3)))
       eslint-plugin-import-x:
         specifier: 4.17.1
-        version: 4.17.1(@typescript-eslint/utils@8.68.0(eslint@9.39.2)(typescript@6.0.3))(eslint@9.39.2)
+        version: 4.17.1(@typescript-eslint/utils@8.68.0(typescript@6.0.3))
       eslint-plugin-jsx-a11y:
         specifier: 6.10.2
-        version: 6.10.2(eslint@9.39.2)
+        version: 6.10.2
       eslint-plugin-react-dom:
         specifier: 2.13.0
-        version: 2.13.0(eslint@9.39.2)(typescript@6.0.3)
+        version: 2.13.0(typescript@6.0.3)
       eslint-plugin-react-hooks:
         specifier: 7.1.1
-        version: 7.1.1(eslint@9.39.2)
+        version: 7.1.1
       eslint-plugin-react-naming-convention:
         specifier: 2.13.0
-        version: 2.13.0(eslint@9.39.2)(typescript@6.0.3)
+        version: 2.13.0(typescript@6.0.3)
       eslint-plugin-react-x:
         specifier: 2.13.0
-        version: 2.13.0(eslint@9.39.2)(typescript@6.0.3)
+        version: 2.13.0(typescript@6.0.3)
       eslint-plugin-security:
         specifier: 4.0.1
         version: 4.0.1
       eslint-plugin-sonarjs:
         specifier: 4.2.0
-        version: 4.2.0(eslint@9.39.2)
-      eslint-plugin-testing-library:
-        specifier: 7.16.2
-        version: 7.16.2(eslint@9.39.2)(typescript@6.0.3)
+        version: 4.2.0
       eslint-plugin-unicorn:
         specifier: 73.0.0
-        version: 73.0.0(eslint@9.39.2)
+        version: 73.0.0
       eslint-plugin-upleveled:
         specifier: 2.1.15
-        version: 2.1.15(eslint@9.39.2)
+        version: 2.1.15
       globals:
         specifier: ^17.11.0
         version: 17.11.0
@@ -92,19 +86,16 @@ importers:
       strip-json-comments:
         specifier: 5.0.3
         version: 5.0.3
-      ts-api-utils:
-        specifier: 2.5.0
-        version: 2.5.0(typescript@6.0.3)
       yaml:
         specifier: ^2.8.1
         version: 2.9.0
     devDependencies:
       '@typescript-eslint/utils':
         specifier: 8.68.0
-        version: 8.68.0(eslint@9.39.2)(typescript@6.0.3)
+        version: 8.68.0(typescript@6.0.3)
       eslint-config-upleveled:
         specifier: 10.0.2
-        version: 10.0.2(@babel/core@7.28.4)(@types/node@26.4.0)(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(@typescript-eslint/utils@8.68.0(eslint@9.39.2)(typescript@6.0.3))(eslint@9.39.2)(globals@17.11.0)(typescript@6.0.3)
+        version: 10.0.2(@babel/core@7.28.4)(@types/node@26.4.0)(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(@typescript-eslint/utils@8.68.0(typescript@6.0.3))(globals@17.11.0)(typescript@6.0.3)
       prettier:
         specifier: 3.9.6
         version: 3.9.6
@@ -2271,11 +2262,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.29.7(@babel/core@7.28.4)(eslint@9.39.2)':
+  '@babel/eslint-parser@7.29.7(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 9.39.2
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
@@ -2407,6 +2397,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.1':
+    dependencies:
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2)':
     dependencies:
       eslint: 9.39.2
@@ -2414,28 +2408,26 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint-react/ast@2.13.0(eslint@9.39.2)(typescript@6.0.3)':
+  '@eslint-react/ast@2.13.0(typescript@6.0.3)':
     dependencies:
       '@eslint-react/eff': 2.13.0
       '@typescript-eslint/types': 8.68.0
       '@typescript-eslint/typescript-estree': 8.68.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.68.0(eslint@9.39.2)(typescript@6.0.3)
-      eslint: 9.39.2
+      '@typescript-eslint/utils': 8.68.0(typescript@6.0.3)
       string-ts: 2.3.1
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/core@2.13.0(eslint@9.39.2)(typescript@6.0.3)':
+  '@eslint-react/core@2.13.0(typescript@6.0.3)':
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.2)(typescript@6.0.3)
+      '@eslint-react/ast': 2.13.0(typescript@6.0.3)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.2)(typescript@6.0.3)
-      '@eslint-react/var': 2.13.0(eslint@9.39.2)(typescript@6.0.3)
+      '@eslint-react/shared': 2.13.0(typescript@6.0.3)
+      '@eslint-react/var': 2.13.0(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.68.0
       '@typescript-eslint/types': 8.68.0
-      '@typescript-eslint/utils': 8.68.0(eslint@9.39.2)(typescript@6.0.3)
-      eslint: 9.39.2
+      '@typescript-eslint/utils': 8.68.0(typescript@6.0.3)
       ts-pattern: 5.9.0
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -2443,36 +2435,32 @@ snapshots:
 
   '@eslint-react/eff@2.13.0': {}
 
-  '@eslint-react/shared@2.13.0(eslint@9.39.2)(typescript@6.0.3)':
+  '@eslint-react/shared@2.13.0(typescript@6.0.3)':
     dependencies:
       '@eslint-react/eff': 2.13.0
-      '@typescript-eslint/utils': 8.68.0(eslint@9.39.2)(typescript@6.0.3)
-      eslint: 9.39.2
+      '@typescript-eslint/utils': 8.68.0(typescript@6.0.3)
       ts-pattern: 5.9.0
       typescript: 6.0.3
       zod: 4.3.5
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint-react/var@2.13.0(eslint@9.39.2)(typescript@6.0.3)':
+  '@eslint-react/var@2.13.0(typescript@6.0.3)':
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.2)(typescript@6.0.3)
+      '@eslint-react/ast': 2.13.0(typescript@6.0.3)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.2)(typescript@6.0.3)
+      '@eslint-react/shared': 2.13.0(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.68.0
       '@typescript-eslint/types': 8.68.0
-      '@typescript-eslint/utils': 8.68.0(eslint@9.39.2)(typescript@6.0.3)
-      eslint: 9.39.2
+      '@typescript-eslint/utils': 8.68.0(typescript@6.0.3)
       ts-pattern: 5.9.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/compat@2.1.0(eslint@9.39.2)':
+  '@eslint/compat@2.1.0':
     dependencies:
       '@eslint/core': 1.2.1
-    optionalDependencies:
-      eslint: 9.39.2
 
   '@eslint/config-array@0.21.1':
     dependencies:
@@ -2567,16 +2555,16 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/eslint-plugin-next@16.3.0(eslint@9.39.2)':
+  '@next/eslint-plugin-next@16.3.0':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2)
+      '@eslint-community/eslint-utils': 4.9.1
       fast-glob: 3.3.1
     transitivePeerDependencies:
       - eslint
 
-  '@next/eslint-plugin-next@16.3.3(eslint@9.39.2)':
+  '@next/eslint-plugin-next@16.3.3':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2)
+      '@eslint-community/eslint-utils': 4.9.1
       fast-glob: 3.3.1
     transitivePeerDependencies:
       - eslint
@@ -2599,11 +2587,10 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
-  '@stylistic/eslint-plugin@5.10.0(eslint@9.39.2)':
+  '@stylistic/eslint-plugin@5.10.0':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2)
+      '@eslint-community/eslint-utils': 4.9.1
       '@typescript-eslint/types': 8.68.0
-      eslint: 9.39.2
       eslint-visitor-keys: 4.2.1
       espree: 10.4.0
       estraverse: 5.3.0
@@ -2632,15 +2619,14 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(eslint@9.39.2)(typescript@6.0.3))(eslint@9.39.2)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.66.0(@typescript-eslint/parser@8.66.0(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.66.0(eslint@9.39.2)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.66.0(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.66.0
-      '@typescript-eslint/type-utils': 8.66.0(eslint@9.39.2)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@9.39.2)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.66.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.66.0
-      eslint: 9.39.2
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -2648,15 +2634,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.68.0(@typescript-eslint/parser@8.68.0(eslint@9.39.2)(typescript@6.0.3))(eslint@9.39.2)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.68.0(@typescript-eslint/parser@8.68.0(typescript@6.0.3))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.68.0(eslint@9.39.2)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.68.0(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.68.0
-      '@typescript-eslint/type-utils': 8.68.0(eslint@9.39.2)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.68.0(eslint@9.39.2)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.68.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.68.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.68.0
-      eslint: 9.39.2
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -2664,26 +2649,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.66.0(eslint@9.39.2)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.66.0(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.66.0
       '@typescript-eslint/types': 8.66.0
       '@typescript-eslint/typescript-estree': 8.66.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.66.0
       debug: 4.4.3
-      eslint: 9.39.2
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.68.0(eslint@9.39.2)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.68.0(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.68.0
       '@typescript-eslint/types': 8.68.0
       '@typescript-eslint/typescript-estree': 8.68.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.68.0
       debug: 4.4.3
-      eslint: 9.39.2
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -2724,25 +2707,23 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.66.0(eslint@9.39.2)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.66.0(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.66.0
       '@typescript-eslint/typescript-estree': 8.66.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.66.0(eslint@9.39.2)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.66.0(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 9.39.2
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.68.0(eslint@9.39.2)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.68.0(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.68.0
       '@typescript-eslint/typescript-estree': 8.68.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.68.0(eslint@9.39.2)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.68.0(typescript@6.0.3)
       debug: 4.4.3
-      eslint: 9.39.2
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -2782,24 +2763,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.66.0(eslint@9.39.2)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.66.0(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2)
+      '@eslint-community/eslint-utils': 4.9.1
       '@typescript-eslint/scope-manager': 8.66.0
       '@typescript-eslint/types': 8.66.0
       '@typescript-eslint/typescript-estree': 8.66.0(typescript@6.0.3)
-      eslint: 9.39.2
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.68.0(eslint@9.39.2)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.68.0(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2)
+      '@eslint-community/eslint-utils': 4.9.1
       '@typescript-eslint/scope-manager': 8.68.0
       '@typescript-eslint/types': 8.68.0
       '@typescript-eslint/typescript-estree': 8.68.0(typescript@6.0.3)
-      eslint: 9.39.2
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -3241,42 +3220,39 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-flat-gitignore@2.3.0(eslint@9.39.2):
+  eslint-config-flat-gitignore@2.3.0:
     dependencies:
-      '@eslint/compat': 2.1.0(eslint@9.39.2)
-      eslint: 9.39.2
+      '@eslint/compat': 2.1.0
 
-  eslint-config-flat-gitignore@2.4.0(eslint@9.39.2):
+  eslint-config-flat-gitignore@2.4.0:
     dependencies:
-      '@eslint/compat': 2.1.0(eslint@9.39.2)
-      eslint: 9.39.2
+      '@eslint/compat': 2.1.0
 
-  eslint-config-upleveled@10.0.2(@babel/core@7.28.4)(@types/node@26.4.0)(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(@typescript-eslint/utils@8.68.0(eslint@9.39.2)(typescript@6.0.3))(eslint@9.39.2)(globals@17.11.0)(typescript@6.0.3):
+  eslint-config-upleveled@10.0.2(@babel/core@7.28.4)(@types/node@26.4.0)(@types/react-dom@19.2.5(@types/react@19.2.18))(@types/react@19.2.18)(@typescript-eslint/utils@8.68.0(typescript@6.0.3))(globals@17.11.0)(typescript@6.0.3):
     dependencies:
-      '@babel/eslint-parser': 7.29.7(@babel/core@7.28.4)(eslint@9.39.2)
-      '@eslint/compat': 2.1.0(eslint@9.39.2)
-      '@next/eslint-plugin-next': 16.3.0(eslint@9.39.2)
-      '@stylistic/eslint-plugin': 5.10.0(eslint@9.39.2)
+      '@babel/eslint-parser': 7.29.7(@babel/core@7.28.4)
+      '@eslint/compat': 2.1.0
+      '@next/eslint-plugin-next': 16.3.0
+      '@stylistic/eslint-plugin': 5.10.0
       '@types/node': 26.4.0
       '@types/react': 19.2.18
       '@types/react-dom': 19.2.5(@types/react@19.2.18)
-      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(eslint@9.39.2)(typescript@6.0.3))(eslint@9.39.2)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.66.0(eslint@9.39.2)(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.66.0(@typescript-eslint/parser@8.66.0(typescript@6.0.3))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.66.0(typescript@6.0.3)
       comment-json: 5.0.0
-      eslint: 9.39.2
-      eslint-config-flat-gitignore: 2.3.0(eslint@9.39.2)
-      eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.68.0(eslint@9.39.2)(typescript@6.0.3))(eslint@9.39.2))(eslint@9.39.2)
-      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.68.0(eslint@9.39.2)(typescript@6.0.3))(eslint@9.39.2)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2)
-      eslint-plugin-react-dom: 2.13.0(eslint@9.39.2)(typescript@6.0.3)
-      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.2)
-      eslint-plugin-react-naming-convention: 2.13.0(eslint@9.39.2)(typescript@6.0.3)
-      eslint-plugin-react-x: 2.13.0(eslint@9.39.2)(typescript@6.0.3)
+      eslint-config-flat-gitignore: 2.3.0
+      eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.68.0(typescript@6.0.3)))
+      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.68.0(typescript@6.0.3))
+      eslint-plugin-jsx-a11y: 6.10.2
+      eslint-plugin-react-dom: 2.13.0(typescript@6.0.3)
+      eslint-plugin-react-hooks: 7.1.1
+      eslint-plugin-react-naming-convention: 2.13.0(typescript@6.0.3)
+      eslint-plugin-react-x: 2.13.0(typescript@6.0.3)
       eslint-plugin-security: 4.0.1
-      eslint-plugin-sonarjs: 4.2.0(eslint@9.39.2)
-      eslint-plugin-testing-library: 7.16.2(eslint@9.39.2)(typescript@6.0.3)
-      eslint-plugin-unicorn: 72.0.0(eslint@9.39.2)
-      eslint-plugin-upleveled: 2.1.15(eslint@9.39.2)
+      eslint-plugin-sonarjs: 4.2.0
+      eslint-plugin-testing-library: 7.16.2(typescript@6.0.3)
+      eslint-plugin-unicorn: 72.0.0
+      eslint-plugin-upleveled: 2.1.15
       globals: 17.11.0
       is-plain-obj: 4.1.0
       sort-package-json: 3.6.1
@@ -3298,10 +3274,9 @@ snapshots:
     optionalDependencies:
       unrs-resolver: 1.11.1
 
-  eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.68.0(eslint@9.39.2)(typescript@6.0.3))(eslint@9.39.2))(eslint@9.39.2):
+  eslint-import-resolver-typescript@4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.68.0(typescript@6.0.3))):
     dependencies:
       debug: 4.4.3
-      eslint: 9.39.2
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       get-tsconfig: 4.10.1
       is-bun-module: 2.0.0
@@ -3309,16 +3284,15 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.68.0(eslint@9.39.2)(typescript@6.0.3))(eslint@9.39.2)
+      eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.68.0(typescript@6.0.3))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.68.0(eslint@9.39.2)(typescript@6.0.3))(eslint@9.39.2):
+  eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.68.0(typescript@6.0.3)):
     dependencies:
       '@typescript-eslint/types': 8.68.0
       comment-parser: 1.4.1
       debug: 4.4.3
-      eslint: 9.39.2
       eslint-import-context: 0.1.9(unrs-resolver@1.11.1)
       is-glob: 4.0.3
       minimatch: 10.2.5
@@ -3326,11 +3300,11 @@ snapshots:
       stable-hash-x: 0.2.0
       unrs-resolver: 1.11.1
     optionalDependencies:
-      '@typescript-eslint/utils': 8.68.0(eslint@9.39.2)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.68.0(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.2):
+  eslint-plugin-jsx-a11y@6.10.2:
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -3340,7 +3314,6 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 9.39.2
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -3349,67 +3322,63 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-dom@2.13.0(eslint@9.39.2)(typescript@6.0.3):
+  eslint-plugin-react-dom@2.13.0(typescript@6.0.3):
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.2)(typescript@6.0.3)
-      '@eslint-react/core': 2.13.0(eslint@9.39.2)(typescript@6.0.3)
+      '@eslint-react/ast': 2.13.0(typescript@6.0.3)
+      '@eslint-react/core': 2.13.0(typescript@6.0.3)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.2)(typescript@6.0.3)
-      '@eslint-react/var': 2.13.0(eslint@9.39.2)(typescript@6.0.3)
+      '@eslint-react/shared': 2.13.0(typescript@6.0.3)
+      '@eslint-react/var': 2.13.0(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.68.0
       '@typescript-eslint/types': 8.68.0
-      '@typescript-eslint/utils': 8.68.0(eslint@9.39.2)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.68.0(typescript@6.0.3)
       compare-versions: 6.1.1
-      eslint: 9.39.2
       ts-pattern: 5.9.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-hooks@7.1.1(eslint@9.39.2):
+  eslint-plugin-react-hooks@7.1.1:
     dependencies:
       '@babel/core': 7.28.4
       '@babel/parser': 7.28.4
-      eslint: 9.39.2
       hermes-parser: 0.25.1
       zod: 4.3.5
       zod-validation-error: 3.5.3(zod@4.3.5)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-naming-convention@2.13.0(eslint@9.39.2)(typescript@6.0.3):
+  eslint-plugin-react-naming-convention@2.13.0(typescript@6.0.3):
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.2)(typescript@6.0.3)
-      '@eslint-react/core': 2.13.0(eslint@9.39.2)(typescript@6.0.3)
+      '@eslint-react/ast': 2.13.0(typescript@6.0.3)
+      '@eslint-react/core': 2.13.0(typescript@6.0.3)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.2)(typescript@6.0.3)
-      '@eslint-react/var': 2.13.0(eslint@9.39.2)(typescript@6.0.3)
+      '@eslint-react/shared': 2.13.0(typescript@6.0.3)
+      '@eslint-react/var': 2.13.0(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.68.0
-      '@typescript-eslint/type-utils': 8.68.0(eslint@9.39.2)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.68.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.68.0
-      '@typescript-eslint/utils': 8.68.0(eslint@9.39.2)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.68.0(typescript@6.0.3)
       compare-versions: 6.1.1
-      eslint: 9.39.2
       string-ts: 2.3.1
       ts-pattern: 5.9.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-x@2.13.0(eslint@9.39.2)(typescript@6.0.3):
+  eslint-plugin-react-x@2.13.0(typescript@6.0.3):
     dependencies:
-      '@eslint-react/ast': 2.13.0(eslint@9.39.2)(typescript@6.0.3)
-      '@eslint-react/core': 2.13.0(eslint@9.39.2)(typescript@6.0.3)
+      '@eslint-react/ast': 2.13.0(typescript@6.0.3)
+      '@eslint-react/core': 2.13.0(typescript@6.0.3)
       '@eslint-react/eff': 2.13.0
-      '@eslint-react/shared': 2.13.0(eslint@9.39.2)(typescript@6.0.3)
-      '@eslint-react/var': 2.13.0(eslint@9.39.2)(typescript@6.0.3)
+      '@eslint-react/shared': 2.13.0(typescript@6.0.3)
+      '@eslint-react/var': 2.13.0(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.68.0
-      '@typescript-eslint/type-utils': 8.68.0(eslint@9.39.2)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.68.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.68.0
-      '@typescript-eslint/utils': 8.68.0(eslint@9.39.2)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.68.0(typescript@6.0.3)
       compare-versions: 6.1.1
-      eslint: 9.39.2
-      is-immutable-type: 5.0.1(eslint@9.39.2)(typescript@6.0.3)
+      is-immutable-type: 5.0.1(typescript@6.0.3)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       ts-pattern: 5.9.0
       typescript: 6.0.3
@@ -3420,12 +3389,11 @@ snapshots:
     dependencies:
       safe-regex: 2.1.1
 
-  eslint-plugin-sonarjs@4.2.0(eslint@9.39.2):
+  eslint-plugin-sonarjs@4.2.0:
     dependencies:
       '@eslint-community/regexpp': 4.12.2
       builtin-modules: 3.3.0
       bytes: 3.1.2
-      eslint: 9.39.2
       functional-red-black-tree: 1.0.1
       globals: 17.11.0
       jsx-ast-utils-x: 0.1.0
@@ -3437,18 +3405,17 @@ snapshots:
       typescript: 6.0.3
       yaml: 2.9.0
 
-  eslint-plugin-testing-library@7.16.2(eslint@9.39.2)(typescript@6.0.3):
+  eslint-plugin-testing-library@7.16.2(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/scope-manager': 8.68.0
-      '@typescript-eslint/utils': 8.68.0(eslint@9.39.2)(typescript@6.0.3)
-      eslint: 9.39.2
+      '@typescript-eslint/utils': 8.68.0(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  eslint-plugin-unicorn@72.0.0(eslint@9.39.2):
+  eslint-plugin-unicorn@72.0.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2)
+      '@eslint-community/eslint-utils': 4.9.1
       '@eslint/css-tree': 4.0.4
       browserslist: 4.28.6
       change-case: 5.4.4
@@ -3456,7 +3423,6 @@ snapshots:
       core-js-compat: 3.49.0
       detect-indent: 7.0.2
       entities: 4.5.0
-      eslint: 9.39.2
       find-up-simple: 1.0.1
       globals: 17.11.0
       indent-string: 5.0.0
@@ -3470,9 +3436,9 @@ snapshots:
       strip-indent: 4.1.1
       yaml: 2.9.0
 
-  eslint-plugin-unicorn@73.0.0(eslint@9.39.2):
+  eslint-plugin-unicorn@73.0.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2)
+      '@eslint-community/eslint-utils': 4.9.1
       '@eslint/css-tree': 4.0.4
       browserslist: 4.28.6
       change-case: 5.4.4
@@ -3480,7 +3446,6 @@ snapshots:
       core-js-compat: 3.49.0
       detect-indent: 7.0.2
       entities: 4.5.0
-      eslint: 9.39.2
       find-up-simple: 1.0.1
       globals: 17.11.0
       indent-string: 5.0.0
@@ -3494,9 +3459,7 @@ snapshots:
       strip-indent: 4.1.1
       yaml: 2.9.0
 
-  eslint-plugin-upleveled@2.1.15(eslint@9.39.2):
-    dependencies:
-      eslint: 9.39.2
+  eslint-plugin-upleveled@2.1.15: {}
 
   eslint-scope@5.1.1:
     dependencies:
@@ -3882,10 +3845,9 @@ snapshots:
       identifier-regex: 1.1.0
       super-regex: 1.1.0
 
-  is-immutable-type@5.0.1(eslint@9.39.2)(typescript@6.0.3):
+  is-immutable-type@5.0.1(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/type-utils': 8.68.0(eslint@9.39.2)(typescript@6.0.3)
-      eslint: 9.39.2
+      '@typescript-eslint/type-utils': 8.68.0(typescript@6.0.3)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       ts-declaration-location: 1.0.7(typescript@6.0.3)
       typescript: 6.0.3


### PR DESCRIPTION
Renovate PR [#670](https://github.com/upleveled/eslint-config-upleveled/pull/670) attempts to upgrade an unused `@babel/eslint-parser`. Babel 8 would also introduce incompatible Node.js and `@babel/core` requirements.

`@babel/eslint-parser` and `eslint-plugin-testing-library` remained after copying the `eslint-config-react-app` peer dependencies in commit [`7d78375`](https://github.com/upleveled/eslint-config-upleveled/commit/7d7837580fe5918859c35ff7287d5fea95460ea0) in 2021. The config selected `@typescript-eslint/parser`, and removed `eslint-config-react-app` in commit [`1880496`](https://github.com/upleveled/eslint-config-upleveled/commit/188049675da47a9438164a8815c8ffe84a698e6c) in 2023.

`ts-api-utils` remained after replacing the vendored `eslint-plugin-jsx-expressions` rule in PR [#424](https://github.com/upleveled/eslint-config-upleveled/pull/424) in 2024.

Remove these unused direct dependencies.

- [x] Remove unused `@babel/eslint-parser`
- [x] Remove unused `eslint-plugin-testing-library`
- [x] Remove unused `ts-api-utils`
- [x] Test with Node.js project
- [x] Test with `create-react-app` project
- [x] Test with Next.js project
- [x] Test with Expo project
