### PR TITLE
Switch from CodeSandbox CI to pnpm Git exotic sources

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,3 +1,0 @@
-{
-  "buildCommand": false
-}


### PR DESCRIPTION
Prerequisite for #654

CodeSandbox CI was [discontinued on April 15, 2026](https://news.ycombinator.com/item?id=47418491#:~:text=CodeSandbox%20CI%3A%20Shutting%20down%20on%20April%2015%2C%202026.%20Migrate%20to%20an%20alternative%20CI%20provider%20before%20then). Its Node.js 20 environment blocks the pnpm 11 upgrade in PR [#654](https://github.com/upleveled/eslint-config-upleveled/pull/654), because [pnpm 11 requires Node.js 22 or newer](https://pnpm.io/blog/releases/11.0#:~:text=It%20also%20requires%20Node.js%2022%20or%20newer%20%E2%80%94%20pnpm%20itself%20is%20now%20pure%20ESM.).

Since `eslint-config-upleveled` has no `build` or `prepare` script and its `main` and `bin` point directly at JavaScript source, contributors can install any branch directly via pnpm [Git repository exotic sources](https://pnpm.io/package-sources#git-repository) without a separate build step:

https://github.com/upleveled/eslint-config-upleveled/blob/88e7871618bdcc6dd950a61a76758f6bac82d1c0/package.json#L34-L36

https://github.com/upleveled/eslint-config-upleveled/blob/88e7871618bdcc6dd950a61a76758f6bac82d1c0/package.json#L22-L25

To test a PR branch, install it using a [Git repository exotic source](https://pnpm.io/package-sources#git-repository) and the branch name, then run the installer:

```bash
pnpm add --save-dev "upleveled/eslint-config-upleveled#switch-codesandbox-to-pnpm-git-sources"
node node_modules/eslint-config-upleveled/bin/install.js
```

- [x] Remove obsolete `.codesandbox/ci.json`

Similar to Preflight PR https://github.com/upleveled/preflight/pull/739
